### PR TITLE
Automatic Reference Counting (ARC) Refactor

### DIFF
--- a/framework/GPUImage.xcodeproj/project.pbxproj
+++ b/framework/GPUImage.xcodeproj/project.pbxproj
@@ -492,6 +492,7 @@
 		BCF1A35914DDB1EC00852800 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
 				DSTROOT = /tmp/GPUImage.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Source/GPUImage-Prefix.pch";
@@ -504,6 +505,7 @@
 		BCF1A35A14DDB1EC00852800 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
 				DSTROOT = /tmp/GPUImage.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Source/GPUImage-Prefix.pch";
@@ -516,6 +518,7 @@
 		BCF1A35C14DDB1EC00852800 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(DEVELOPER_LIBRARY_DIR)/Frameworks",
@@ -531,6 +534,7 @@
 		BCF1A35D14DDB1EC00852800 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(DEVELOPER_LIBRARY_DIR)/Frameworks",

--- a/framework/Source/GLProgram.m
+++ b/framework/Source/GLProgram.m
@@ -194,7 +194,7 @@ typedef void (*GLLogFunction) (GLuint program,
                                               length:logLength 
                                             encoding:NSUTF8StringEncoding];
     free(logBytes);
-    return [log autorelease];
+    return log;
 }
 // END:privatelog
 // START:log
@@ -238,8 +238,6 @@ typedef void (*GLLogFunction) (GLuint program,
 // START:dealloc
 - (void)dealloc
 {
-    [attributes release];
-    [uniforms release];
   
     if (vertShader)
         glDeleteShader(vertShader);
@@ -250,7 +248,6 @@ typedef void (*GLLogFunction) (GLuint program,
     if (program)
         glDeleteProgram(program);
        
-    [super dealloc];
 }
 // END:dealloc
 @end

--- a/framework/Source/GPUImageFilter.m
+++ b/framework/Source/GPUImageFilter.m
@@ -94,8 +94,6 @@ void dataProviderReleaseCallback (void *info, const void *data, size_t size);
 {
     [self destroyFilterFBO];
     
-    [filterProgram release];
-    [super dealloc];
 }
 
 #pragma mark -
@@ -142,7 +140,6 @@ void dataProviderReleaseCallback (void *info, const void *data, size_t size)
     UIImage *processedImage = [self imageFromCurrentlyProcessedOutput];
     
     [stillImageSource removeTarget:self];
-    [stillImageSource release];
     return processedImage;
 }
 

--- a/framework/Source/GPUImageOutput.m
+++ b/framework/Source/GPUImageOutput.m
@@ -22,10 +22,8 @@
 - (void)dealloc 
 {
     [self removeAllTargets];
-    [targets release];
     [self deleteOutputTexture];
     
-	[super dealloc];
 }
 
 #pragma mark -

--- a/framework/Source/GPUImagePicture.m
+++ b/framework/Source/GPUImagePicture.m
@@ -12,7 +12,7 @@
 		return nil;
     }
 
-    imageSource = [newImageSource retain];
+    imageSource = newImageSource;
 
     [GPUImageOpenGLESContext useImageProcessingContext];
 
@@ -38,12 +38,6 @@
     return self;
 }
 
-- (void)dealloc;
-{
-    [imageSource release];
-    
-    [super dealloc];
-}
 
 
 #pragma mark -

--- a/framework/Source/GPUImageVideoCamera.m
+++ b/framework/Source/GPUImageVideoCamera.m
@@ -94,11 +94,7 @@
     [captureSession removeInput:videoInput];
     [captureSession removeOutput:videoOutput];
 
-	[captureSession release];
-	[videoOutput release];
-	[videoInput release];
 
-	[super dealloc];
 }
 
 #pragma mark -

--- a/framework/Source/GPUImageView.m
+++ b/framework/Source/GPUImageView.m
@@ -130,9 +130,7 @@ void main()\
 
 - (void)dealloc
 {
-    [displayProgram release];
     [self destroyDisplayFramebuffer];
-    [super dealloc];
 }
 
 #pragma mark -


### PR DESCRIPTION
I would vote that the merits of performance and ease of development of ARC are too many to deny, especially in regards to an open-source project with disparate contributors. Using ARC would make your life of merging pull requests much easier, and without worry of poorly written code causing memory leaks.

I am assuming most projects using GPUImage will be new projects, and should be using ARC anyway. If they are not, they can still use GPUImage by including the pre-built library.

ARC is supported in iOS 4.0+, which matches this project's goals.
