### PR TITLE
Fix two error.

### DIFF
--- a/framework/Source/GPUImageOpenGLESContext.h
+++ b/framework/Source/GPUImageOpenGLESContext.h
@@ -6,6 +6,7 @@
 
 @interface GPUImageOpenGLESContext : NSObject
 {
+    EAGLContext *_context;
 }
 
 @property(readonly) EAGLContext *context;

--- a/framework/Source/GPUImageVideoCamera.h
+++ b/framework/Source/GPUImageVideoCamera.h
@@ -14,6 +14,8 @@
 
     NSUInteger numberOfFramesCaptured;
     CGFloat totalFrameTimeDuringCapture;
+    
+    AVCaptureSession *_captureSession;
 }
 
 @property(readonly) AVCaptureSession *captureSession;


### PR DESCRIPTION
Fix two error saying "ARC forbids synthesizing a property of an Objective-C object with unspecified ownership or storage attribute" when using ARC.
