### PR TITLE
Ability to enable/disable GPUImageOutputs. Replaced all references to self in blocks with __unsafe_unretained self. Added method to retrieve the CMSampleBufferRef directly from GPUImageStillCamera

### DIFF
--- a/framework/Source/GPUImageMovie.m
+++ b/framework/Source/GPUImageMovie.m
@@ -70,6 +70,8 @@
     NSDictionary *inputOptions = [NSDictionary dictionaryWithObject:[NSNumber numberWithBool:YES] forKey:AVURLAssetPreferPreciseDurationAndTimingKey];
     AVURLAsset *inputAsset = [[AVURLAsset alloc] initWithURL:self.url options:inputOptions];
     
+    __unsafe_unretained __typeof__(self) weakSelf = self;
+    
     [inputAsset loadValuesAsynchronouslyForKeys:[NSArray arrayWithObject:@"tracks"] completionHandler: ^{
         NSError *error = nil;
         AVKeyValueStatus tracksStatus = [inputAsset statusOfValueForKey:@"tracks" error:&error];
@@ -86,7 +88,7 @@
         [reader addOutput:readerVideoTrackOutput];
         
         NSArray *audioTracks = [inputAsset tracksWithMediaType:AVMediaTypeAudio];
-        BOOL shouldRecordAudioTrack = (([audioTracks count] > 0) && (self.audioEncodingTarget != nil) );
+        BOOL shouldRecordAudioTrack = (([audioTracks count] > 0) && (weakSelf.audioEncodingTarget != nil) );
         AVAssetReaderTrackOutput *readerAudioTrackOutput = nil;
 
         if (shouldRecordAudioTrack)
@@ -101,14 +103,12 @@
 
         if ([reader startReading] == NO) 
         {
-            NSLog(@"Error reading from file at URL: %@", self.url);
+            NSLog(@"Error reading from file at URL: %@", weakSelf.url);
             return;
         }
         
         if (synchronizedMovieWriter != nil)
         {
-            __unsafe_unretained GPUImageMovie *weakSelf = self;
-            
             [synchronizedMovieWriter setVideoInputReadyCallback:^{
                 [weakSelf readNextVideoFrameFromOutput:readerVideoTrackOutput];
             }];
@@ -123,17 +123,17 @@
         {
             while (reader.status == AVAssetReaderStatusReading) 
             {
-                [self readNextVideoFrameFromOutput:readerVideoTrackOutput];
+                [weakSelf readNextVideoFrameFromOutput:readerVideoTrackOutput];
                 
                 if ( (shouldRecordAudioTrack) && (!audioEncodingIsFinished) )
                 {
-                    [self readNextAudioSampleFromOutput:readerAudioTrackOutput];
+                    [weakSelf readNextAudioSampleFromOutput:readerAudioTrackOutput];
                 }
                 
             }            
 
             if (reader.status == AVAssetWriterStatusCompleted) {
-                [self endProcessing];
+                [weakSelf endProcessing];
             }
         }
     }];
@@ -146,8 +146,9 @@
         CMSampleBufferRef sampleBufferRef = [readerVideoTrackOutput copyNextSampleBuffer];
         if (sampleBufferRef) 
         {
+            __unsafe_unretained __typeof__(self) weakSelf = self;
             runOnMainQueueWithoutDeadlocking(^{
-                [self processMovieFrame:sampleBufferRef]; 
+                [weakSelf processMovieFrame:sampleBufferRef];
             });
             
             CMSampleBufferInvalidate(sampleBufferRef);

--- a/framework/Source/GPUImageOutput.h
+++ b/framework/Source/GPUImageOutput.h
@@ -34,6 +34,7 @@ void report_memory(NSString *tag);
 @property(readwrite, nonatomic, retain) GPUImageMovieWriter *audioEncodingTarget;
 @property(readwrite, nonatomic, unsafe_unretained) id<GPUImageInput> targetToIgnoreForUpdates;
 @property(nonatomic, copy) void(^frameProcessingCompletionBlock)(GPUImageOutput*, CMTime);
+@property(nonatomic) BOOL enabled;
 
 /// @name Managing targets
 - (void)setInputTextureForTarget:(id<GPUImageInput>)target atIndex:(NSInteger)inputTextureIndex;
@@ -69,6 +70,12 @@ void report_memory(NSString *tag);
 /** Removes all targets.
  */
 - (void)removeAllTargets;
+
+/// @name The state of the GPUImageOutput
+
+/** Returns a BOOL indicating whether the GPUImageOutput is enabled or not. Default is YES.
+ */
+- (BOOL)isEnabled;
 
 /// @name Manage the output texture
 

--- a/framework/Source/GPUImageOutput.m
+++ b/framework/Source/GPUImageOutput.m
@@ -44,6 +44,7 @@ void report_memory(NSString *tag)
 @synthesize audioEncodingTarget = _audioEncodingTarget;
 @synthesize targetToIgnoreForUpdates = _targetToIgnoreForUpdates;
 @synthesize frameProcessingCompletionBlock = _frameProcessingCompletionBlock;
+@synthesize enabled = _enabled;
 
 #pragma mark -
 #pragma mark Initialization and teardown
@@ -57,6 +58,7 @@ void report_memory(NSString *tag)
 
     targets = [[NSMutableArray alloc] init];
     targetTextureIndices = [[NSMutableArray alloc] init];
+    _enabled = YES;
     
     [self initializeOutputTexture];
 
@@ -67,6 +69,13 @@ void report_memory(NSString *tag)
 {
     [self removeAllTargets];
     [self deleteOutputTexture];
+}
+
+#pragma mark -
+#pragma mark Status
+
+- (BOOL)isEnabled {
+    return _enabled;
 }
 
 #pragma mark -

--- a/framework/Source/GPUImageStillCamera.h
+++ b/framework/Source/GPUImageStillCamera.h
@@ -5,6 +5,7 @@ void GPUImageCreateResizedSampleBuffer(CVPixelBufferRef cameraFrame, CGSize fina
 @interface GPUImageStillCamera : GPUImageVideoCamera
 
 // Photography controls
+//- (void)capturePhotoAsSampleBufferWithCompletionHandler:(void (^)(CMSampleBufferRef imageSampleBuffer, NSError *error))block;
 - (void)capturePhotoAsImageProcessedUpToFilter:(GPUImageOutput<GPUImageInput> *)finalFilterInChain withCompletionHandler:(void (^)(UIImage *processedImage, NSError *error))block;
 - (void)capturePhotoAsJPEGProcessedUpToFilter:(GPUImageOutput<GPUImageInput> *)finalFilterInChain withCompletionHandler:(void (^)(NSData *processedJPEG, NSError *error))block;
 - (void)capturePhotoAsPNGProcessedUpToFilter:(GPUImageOutput<GPUImageInput> *)finalFilterInChain withCompletionHandler:(void (^)(NSData *processedPNG, NSError *error))block;

--- a/framework/Source/GPUImageStillCamera.m
+++ b/framework/Source/GPUImageStillCamera.m
@@ -83,6 +83,16 @@ void GPUImageCreateResizedSampleBuffer(CVPixelBufferRef cameraFrame, CGSize fina
 #pragma mark -
 #pragma mark Photography controls
 
+/*- (void)capturePhotoAsSampleBufferWithCompletionHandler:(void (^)(CMSampleBufferRef imageSampleBuffer, NSError *error))block
+{
+    [photoOutput captureStillImageAsynchronouslyFromConnection:[[photoOutput connections] objectAtIndex:0] completionHandler:^(CMSampleBufferRef imageSampleBuffer, NSError *error) {
+#error If you want to use this method, you must comment out the line in initWithSessionPreset:cameraPosition: which sets the CVPixelBufferPixelFormatTypeKey. However, if you do this you cannot use any of the below methods to take a photo if you also supply a filter.
+        block(imageSampleBuffer, error);
+    }];
+    
+    return;
+}*/
+
 - (void)capturePhotoAsImageProcessedUpToFilter:(GPUImageOutput<GPUImageInput> *)finalFilterInChain withCompletionHandler:(void (^)(UIImage *processedImage, NSError *error))block;
 {
     [photoOutput captureStillImageAsynchronouslyFromConnection:[[photoOutput connections] objectAtIndex:0] completionHandler:^(CMSampleBufferRef imageSampleBuffer, NSError *error) {

--- a/framework/Source/GPUImageVideoCamera.m
+++ b/framework/Source/GPUImageVideoCamera.m
@@ -288,22 +288,24 @@
 
         for (id<GPUImageInput> currentTarget in targets)
         {
-            NSInteger indexOfObject = [targets indexOfObject:currentTarget];
-            NSInteger textureIndexOfTarget = [[targetTextureIndices objectAtIndex:indexOfObject] integerValue];
-
-            if (currentTarget != self.targetToIgnoreForUpdates)
-            {
-                [currentTarget setInputSize:CGSizeMake(bufferWidth, bufferHeight) atIndex:textureIndexOfTarget];
+            if ([(GPUImageOutput *)currentTarget respondsToSelector:@selector(enabled)] && [(GPUImageOutput *)currentTarget isEnabled]) {
+                NSInteger indexOfObject = [targets indexOfObject:currentTarget];
+                NSInteger textureIndexOfTarget = [[targetTextureIndices objectAtIndex:indexOfObject] integerValue];
                 
-                [currentTarget setInputTexture:outputTexture atIndex:textureIndexOfTarget];
-                [currentTarget setInputRotation:outputRotation atIndex:textureIndexOfTarget];
-                
-                [currentTarget newFrameReadyAtTime:currentTime];
-            }
-            else
-            {
-                [currentTarget setInputTexture:outputTexture atIndex:textureIndexOfTarget];
-                [currentTarget setInputRotation:outputRotation atIndex:textureIndexOfTarget];
+                if (currentTarget != self.targetToIgnoreForUpdates)
+                {
+                    [currentTarget setInputSize:CGSizeMake(bufferWidth, bufferHeight) atIndex:textureIndexOfTarget];
+                    
+                    [currentTarget setInputTexture:outputTexture atIndex:textureIndexOfTarget];
+                    [currentTarget setInputRotation:outputRotation atIndex:textureIndexOfTarget];
+                    
+                    [currentTarget newFrameReadyAtTime:currentTime];
+                }
+                else
+                {
+                    [currentTarget setInputTexture:outputTexture atIndex:textureIndexOfTarget];
+                    [currentTarget setInputRotation:outputRotation atIndex:textureIndexOfTarget];
+                }
             }
         }
         
@@ -342,13 +344,15 @@
         
         for (id<GPUImageInput> currentTarget in targets)
         {
-            if (currentTarget != self.targetToIgnoreForUpdates)
-            {
-                NSInteger indexOfObject = [targets indexOfObject:currentTarget];
-                NSInteger textureIndexOfTarget = [[targetTextureIndices objectAtIndex:indexOfObject] integerValue];
-
-                [currentTarget setInputSize:CGSizeMake(bufferWidth, bufferHeight) atIndex:textureIndexOfTarget];
-                [currentTarget newFrameReadyAtTime:currentTime];
+            if ([(GPUImageOutput *)currentTarget respondsToSelector:@selector(enabled)] && [(GPUImageOutput *)currentTarget isEnabled]) {
+                if (currentTarget != self.targetToIgnoreForUpdates)
+                {
+                    NSInteger indexOfObject = [targets indexOfObject:currentTarget];
+                    NSInteger textureIndexOfTarget = [[targetTextureIndices objectAtIndex:indexOfObject] integerValue];
+                    
+                    [currentTarget setInputSize:CGSizeMake(bufferWidth, bufferHeight) atIndex:textureIndexOfTarget];
+                    [currentTarget newFrameReadyAtTime:currentTime];
+                }
             }
         }
         
@@ -388,16 +392,17 @@
 	@autoreleasepool 
 	{
 		//these need to be on the main thread for proper timing
+        __unsafe_unretained __typeof__(self) weakSelf = self;
 		if (captureOutput == audioOutput)
 		{
 			runOnMainQueueWithoutDeadlocking(^{ 
-                [self processAudioSampleBuffer:sampleBuffer]; 
+                [weakSelf processAudioSampleBuffer:sampleBuffer];
             });
 		}
 		else
 		{
 			runOnMainQueueWithoutDeadlocking(^{ 
-                [self processVideoSampleBuffer:sampleBuffer]; 
+                [weakSelf processVideoSampleBuffer:sampleBuffer];
             });
 		}
 	}


### PR DESCRIPTION
Added ability to enable/disabled GPUImageOutputs: Much faster way to turn them on or off than by removing and adding them each time. 

Replaced all references to self in blocks with **unsafe_unretained __typeof**(self) weakSelf = self; 

Added method to GPUImageStillCamera to take a photo and retrieve the CMSampleBufferRef directly. Despite being functional, I left this method commented out. To use it, you have to set the camera pixel format to its native setting, which is incompatible with GPUImage.
