### PR TITLE
imageByFilteringImage: Is influenced by device orientation

### DIFF
--- a/framework/Source/GPUImageFilter.m
+++ b/framework/Source/GPUImageFilter.m
@@ -206,7 +206,7 @@ void dataProviderUnlockCallback (void *info, const void *data, size_t size)
     [stillImageSource addTarget:self];
     [stillImageSource processImage];
     
-    UIImage *processedImage = [self imageFromCurrentlyProcessedOutput];
+    UIImage *processedImage = [self imageFromCurrentlyProcessedOutputWithOrientation:[imageToFilter imageOrientation]];
     
     [stillImageSource removeTarget:self];
     return processedImage;


### PR DESCRIPTION
This was causing incorrect behavior for us, and it's probably not right in general.  Basically if you have a single UIImage and you're trying to run in through a filter, the orientation of the output image should end up being the same as the orientation of the input image.    

Before change, Orientation=UpsideDown, image orientation down:

http://i.imgur.com/BgDXr.jpg

After change, Orientation=UpsideDown, image orientation up:

http://imgur.com/icvKV
