### PR TITLE
Change to insure my previous additions don't effect the expected behavior of startRecording

### DIFF
--- a/framework/Source/GPUImageMovieWriter.m
+++ b/framework/Source/GPUImageMovieWriter.m
@@ -223,18 +223,18 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
 
 - (void)startRecording;
 {
-	[self startRecordingInOrientation:CGAffineTransformMakeRotation(0)];
+    isRecording = YES;
+    startTime = kCMTimeInvalid;
+	//    [assetWriter startWriting];
+    
+	//    [assetWriter startSessionAtSourceTime:kCMTimeZero];
 }
 
 - (void)startRecordingInOrientation:(CGAffineTransform)orientationTransform;
 {
 	assetWriterVideoInput.transform = orientationTransform;
-	
-    isRecording = YES;
-    startTime = kCMTimeInvalid;
-//    [assetWriter startWriting];
-    
-//    [assetWriter startSessionAtSourceTime:kCMTimeZero];
+
+	[self startRecording];
 }
 
 - (void)finishRecording;


### PR DESCRIPTION
Made change so a CGAffineTransform isn't applied to a movie when using the startRecording method in GPUImageMovieWriter #366 to insure the behavior of this method isn't change by my addition of startRecordingInOrientation:.
