### PR TITLE
Send the endProcessing message to targets when they get removed.

### DIFF
--- a/framework/Source/GPUImageOutput.m
+++ b/framework/Source/GPUImageOutput.m
@@ -141,9 +141,10 @@ void report_memory(NSString *tag)
     NSInteger textureIndexOfTarget = [[targetTextureIndices objectAtIndex:indexOfObject] integerValue];
     [targetToRemove setInputSize:CGSizeZero atIndex:textureIndexOfTarget];
     [targetToRemove setInputTexture:0 atIndex:textureIndexOfTarget];
-    
+
     [targetTextureIndices removeObjectAtIndex:indexOfObject];
     [targets removeObject:targetToRemove];
+    [targetToRemove endProcessing];
 }
 
 - (void)removeAllTargets;


### PR DESCRIPTION
This resolves an issue with GPUImageMovieWriter and it's delegate methods or completion block not being called when a movie writer has finished.
