### PR TITLE
Synthesize contextQueue to allow for compilation of project

### DIFF
--- a/framework/Source/GPUImageOpenGLESContext.m
+++ b/framework/Source/GPUImageOpenGLESContext.m
@@ -6,6 +6,7 @@
 
 @synthesize context = _context;
 @synthesize currentShaderProgram = _currentShaderProgram;
+@synthesize contextQueue = _contextQueue;
 
 - (id)init;
 {


### PR DESCRIPTION
contextQueue was not being synthesized in GPUImageOpenGLESContext. It was necessary to compile the project.
