### PR TITLE
added an encodingProgressBlock to allow one to get the progress state when a movie is being encoded

### DIFF
--- a/framework/Source/GPUImageMovie.h
+++ b/framework/Source/GPUImageMovie.h
@@ -5,14 +5,16 @@
 
 /** Source object for filtering movies
  */
-@interface GPUImageMovie : GPUImageOutput
+@interface GPUImageMovie : GPUImageOutput{
+}
 
 @property (readwrite, retain) AVAsset *asset;
 @property(readwrite, retain) NSURL *url;
-
 /** This enables the benchmarking mode, which logs out instantaneous and average frame times to the console
  */
 @property(readwrite, nonatomic) BOOL runBenchmark;
+
+@property(nonatomic, copy) void(^encodingProgressBlock)(float);
 
 /// @name Initialization and teardown
 - (id)initWithAsset:(AVAsset *)asset;
@@ -25,6 +27,6 @@
 - (void)readNextAudioSampleFromOutput:(AVAssetReaderTrackOutput *)readerAudioTrackOutput;
 - (void)startProcessing;
 - (void)endProcessing;
-- (void)processMovieFrame:(CMSampleBufferRef)movieSampleBuffer; 
+- (void)processMovieFrame:(CMSampleBufferRef)movieSampleBuffer;
 
 @end


### PR DESCRIPTION
Hi brad..

i've added an encodingProgressBlock to allow one to get the progress state when a movie is being encoded

this is how it works:

[movieFile setEncodingProgressBlock:^(float progress){
            //NSLog(@"progress  %f", progress);
            //values start from 0.0 and finish at 1.0
            [ProgressBar setProgress:progress];
        }];
        [movieWriter setCompletionBlock:^{
            NSLog(@"video encoding done");
            [ProgressBar dismissWithStatus@"done"];
            [anyFilter removeTarget:movieWriter];
            [movieWriter finishRecording];
            UISaveVideoAtPathToSavedPhotosAlbum(pathToMovie, nil, nil,
nil);
        }];

I really should have used properties instead of creating my own getters
and setters… i didn't plan to have that many.. Brad maybe you can just
optimise the code.

It does work like a charm though. Before you would only be able to set
a completion block and while the movie was being encoded there was no
way of telling how long it would take or how much of the encoding
process was left. so i created this to cater for that.
