### PR TITLE
Crop filter: validate the crop rect before assigning it

### DIFF
--- a/framework/Source/GPUImageCropFilter.m
+++ b/framework/Source/GPUImageCropFilter.m
@@ -229,6 +229,11 @@ NSString *const kGPUImageCropFragmentShaderString =  SHADER_STRING
 
 - (void)setCropRegion:(CGRect)newValue;
 {
+    NSParameterAssert(newValue.origin.x >= 0 && newValue.origin.x <= 1 &&
+                      newValue.origin.y >= 0 && newValue.origin.y <= 1 &&
+                      newValue.size.width >= 0 && newValue.size.width <= 1 &&
+                      newValue.size.height >= 0 && newValue.size.height <= 1);
+
     _cropRegion = newValue;
     [self calculateCropTextureCoordinates];
 }


### PR DESCRIPTION
The crop rect must have all fields set to values between 0 and 1. Not doing so leads to a cryptic crash that looks a lot like this: https://github.com/BradLarson/GPUImage/issues/179.

Added an assertion to the crop rect before assigning it so any input error can be caught immediately.
