### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ To filter live video from an iOS device's camera, you can use code like the foll
 
 	// Add the view somewhere so it's visible
 
-	[videoCamera addTarget:thresholdFilter];
+	[videoCamera addTarget:customFilter];
 	[customFilter addTarget:filteredVideoView];
 
 	[videoCamera startCameraCapture];


### PR DESCRIPTION
In the example code for adding a custom filter to a video feed, I replaced `thresholdFilter` with `customFilter`. This caught me up for a few minutes when I was testing out the project with the example code, since it wasn't clear if thresholdFilter was defined somewhere else.
