### PR TITLE
the GPUImageToneCurveFilter now can take into account the rgbcomposite c...

### DIFF
--- a/framework/Source/GPUImageToneCurveFilter.h
+++ b/framework/Source/GPUImageToneCurveFilter.h
@@ -5,12 +5,16 @@
 @property(readwrite, nonatomic, copy) NSArray *redControlPoints;
 @property(readwrite, nonatomic, copy) NSArray *greenControlPoints;
 @property(readwrite, nonatomic, copy) NSArray *blueControlPoints;
+@property(readwrite, nonatomic, copy) NSArray *rgbCompositeControlPoints;
 
 // Initialization and teardown
 - (id)initWithACV:(NSString*)curveFile;
 
 // This lets you set all three red, green, and blue tone curves at once.
-- (void)setRGBControlPoints:(NSArray *)points;
+// NOTE: Deprecated this function because this effect can be accomplished
+// using the rgbComposite channel rather then setting all 3 R, G, and B channels.
+- (void)setRGBControlPoints:(NSArray *)points DEPRECATED_ATTRIBUTE;
+
 - (void)setPointsWithACV:(NSString*)curveFile;
 
 // Curve calculation


### PR DESCRIPTION
With this change the GPUImageToneCurveFilter now can take into account the rgbcomposite channel together with the separate r, g, and b channels

See this bug report:
https://github.com/BradLarson/GPUImage/issues/417
