### PR TITLE
Front rotation fix

### DIFF
--- a/framework/Source/GPUImageVideoCamera.m
+++ b/framework/Source/GPUImageVideoCamera.m
@@ -559,8 +559,8 @@
             switch(_outputImageOrientation)
             {
                 case UIInterfaceOrientationPortrait:outputRotation = kGPUImageRotateRight; break;
-                case UIInterfaceOrientationPortraitUpsideDown:outputRotation = kGPUImageRotateLeft; break;
-                case UIInterfaceOrientationLandscapeLeft:outputRotation = kGPUImageNoRotation; break;
+                case UIInterfaceOrientationPortraitUpsideDown:outputRotation = kGPUImageRotateRightFlipVertical; break;
+                case UIInterfaceOrientationLandscapeLeft:outputRotation = kGPUImageFlipVertical; break;
                 case UIInterfaceOrientationLandscapeRight:outputRotation = kGPUImageRotate180; break;
             }
         }
@@ -568,9 +568,9 @@
         {
             switch(_outputImageOrientation)
             {
-                case UIInterfaceOrientationPortrait:outputRotation = kGPUImageRotateRight; break;
-                case UIInterfaceOrientationPortraitUpsideDown:outputRotation = kGPUImageRotateLeft; break;
-                case UIInterfaceOrientationLandscapeLeft:outputRotation = kGPUImageRotate180; break;
+                case UIInterfaceOrientationPortrait:outputRotation = kGPUImageRotateRightFlipVertical; break;
+                case UIInterfaceOrientationPortraitUpsideDown:outputRotation = kGPUImageRotateRight; break;
+                case UIInterfaceOrientationLandscapeLeft:outputRotation = kGPUImageFlipVertical; break;
                 case UIInterfaceOrientationLandscapeRight:outputRotation = kGPUImageNoRotation; break;
             }
         }


### PR DESCRIPTION
Fixes rotation behavior for the front camera by reverting changes to GPUImageVideoCamera made in https://github.com/BradLarson/GPUImage/commit/d87d057ada1291be3faccc1e79b020ef299156a1

The rotation settings for the back camera probably don't need to change, but I wanted to keep this consistent with the "reverting that change" concept.
