### PR TITLE
Update GPUImageVideoCamera inputCamera property after rotating camera

### DIFF
--- a/framework/Source/GPUImageVideoCamera.m
+++ b/framework/Source/GPUImageVideoCamera.m
@@ -1,4 +1,3 @@
-
 #import "GPUImageVideoCamera.h"
 #import "GPUImageMovieWriter.h"
 
@@ -255,6 +254,7 @@
         [_captureSession commitConfiguration];
     }
     
+    _inputCamera = backFacingCamera;
     [self setOutputImageOrientation:_outputImageOrientation];
 }
 


### PR DESCRIPTION
The `inputCamera` property is only set on initialization. Update it correctly when `rotateCamera` is called.
