### PR TITLE
Fixes forceProcessingAtSize: bugs and also allows access to the AVCaptureConnection of a GPUImageVideoCamera

### DIFF
--- a/framework/Source/GPUImageFilter.m
+++ b/framework/Source/GPUImageFilter.m
@@ -832,6 +832,15 @@ void dataProviderUnlockCallback (void *info, const void *data, size_t size)
         inputTextureSize = frameSize;
         forcedMaximumSize = CGSizeZero;
     }
+    
+    [self destroyFilterFBO];
+    
+    for (id<GPUImageInput> currentTarget in targets)
+    {
+        if ([currentTarget respondsToSelector:@selector(destroyFilterFBO)]) {
+            [currentTarget performSelector:@selector(destroyFilterFBO)];
+        }
+    }
 }
 
 - (void)forceProcessingAtSizeRespectingAspectRatio:(CGSize)frameSize;
@@ -846,6 +855,15 @@ void dataProviderUnlockCallback (void *info, const void *data, size_t size)
     {
         overrideInputSize = YES;
         forcedMaximumSize = frameSize;
+    }
+    
+    [self destroyFilterFBO];
+    
+    for (id<GPUImageInput> currentTarget in targets)
+    {
+        if ([currentTarget respondsToSelector:@selector(destroyFilterFBO)]) {
+            [currentTarget performSelector:@selector(destroyFilterFBO)];
+        }
     }
 }
 

--- a/framework/Source/GPUImageOpenGLESContext.h
+++ b/framework/Source/GPUImageOpenGLESContext.h
@@ -32,7 +32,7 @@ typedef enum { kGPUImageNoRotation, kGPUImageRotateLeft, kGPUImageRotateRight, k
 
 @end
 
-@protocol GPUImageInput
+@protocol GPUImageInput <NSObject>
 - (void)newFrameReadyAtTime:(CMTime)frameTime atIndex:(NSInteger)textureIndex;
 - (void)setInputTexture:(GLuint)newInputTexture atIndex:(NSInteger)textureIndex;
 - (NSInteger)nextAvailableTextureIndex;

--- a/framework/Source/GPUImageStillCamera.h
+++ b/framework/Source/GPUImageStillCamera.h
@@ -6,7 +6,7 @@ void GPUImageCreateResizedSampleBuffer(CVPixelBufferRef cameraFrame, CGSize fina
 @interface GPUImageStillCamera : GPUImageVideoCamera
 
 // Photography controls
-//- (void)capturePhotoAsSampleBufferWithCompletionHandler:(void (^)(CMSampleBufferRef imageSampleBuffer, NSError *error))block;
+- (void)capturePhotoAsSampleBufferWithCompletionHandler:(void (^)(CMSampleBufferRef imageSampleBuffer, NSError *error))block;
 - (void)capturePhotoAsImageProcessedUpToFilter:(GPUImageOutput<GPUImageInput> *)finalFilterInChain withCompletionHandler:(void (^)(UIImage *processedImage, NSError *error))block;
 - (void)capturePhotoAsJPEGProcessedUpToFilter:(GPUImageOutput<GPUImageInput> *)finalFilterInChain withCompletionHandler:(void (^)(NSData *processedJPEG, NSError *error))block;
 - (void)capturePhotoAsPNGProcessedUpToFilter:(GPUImageOutput<GPUImageInput> *)finalFilterInChain withCompletionHandler:(void (^)(NSData *processedPNG, NSError *error))block;

--- a/framework/Source/GPUImageStillCamera.m
+++ b/framework/Source/GPUImageStillCamera.m
@@ -88,15 +88,18 @@ void GPUImageCreateResizedSampleBuffer(CVPixelBufferRef cameraFrame, CGSize fina
 #pragma mark -
 #pragma mark Photography controls
 
-/*- (void)capturePhotoAsSampleBufferWithCompletionHandler:(void (^)(CMSampleBufferRef imageSampleBuffer, NSError *error))block
+- (void)capturePhotoAsSampleBufferWithCompletionHandler:(void (^)(CMSampleBufferRef imageSampleBuffer, NSError *error))block
 {
+    NSLog(@"If you want to use the method capturePhotoAsSampleBufferWithCompletionHandler:, you must comment out the line in GPUImageStillCamera.m in the method initWithSessionPreset:cameraPosition: which sets the CVPixelBufferPixelFormatTypeKey, as well as uncomment the rest of the method capturePhotoAsSampleBufferWithCompletionHandler:. However, if you do this you cannot use any of the photo capture methods to take a photo if you also supply a filter.");
+    
+    /*dispatch_semaphore_wait(frameRenderingSemaphore, DISPATCH_TIME_FOREVER);
+    
     [photoOutput captureStillImageAsynchronouslyFromConnection:[[photoOutput connections] objectAtIndex:0] completionHandler:^(CMSampleBufferRef imageSampleBuffer, NSError *error) {
-#error If you want to use this method, you must comment out the line in initWithSessionPreset:cameraPosition: which sets the CVPixelBufferPixelFormatTypeKey. However, if you do this you cannot use any of the below methods to take a photo if you also supply a filter.
         block(imageSampleBuffer, error);
-    }];
+    }];*/
     
     return;
-}*/
+}
 
 - (void)capturePhotoAsImageProcessedUpToFilter:(GPUImageOutput<GPUImageInput> *)finalFilterInChain withCompletionHandler:(void (^)(UIImage *processedImage, NSError *error))block;
 {

--- a/framework/Source/GPUImageVideoCamera.h
+++ b/framework/Source/GPUImageVideoCamera.h
@@ -110,6 +110,10 @@
  */
 - (AVCaptureDevicePosition)cameraPosition;
 
+/** Get the AVCaptureConnection of the source camera
+ */
+- (AVCaptureConnection *)videoCaptureConnection;
+
 /** This flips between the front and rear cameras
  */
 - (void)rotateCamera;

--- a/framework/Source/GPUImageVideoCamera.m
+++ b/framework/Source/GPUImageVideoCamera.m
@@ -322,6 +322,18 @@
 	return _frameRate;
 }
 
+- (AVCaptureConnection *)videoCaptureConnection {
+    for (AVCaptureConnection *connection in [videoOutput connections] ) {
+		for ( AVCaptureInputPort *port in [connection inputPorts] ) {
+			if ( [[port mediaType] isEqual:AVMediaTypeVideo] ) {
+				return connection;
+			}
+		}
+	}
+    
+    return nil;
+}
+
 #define INITIALFRAMESTOIGNOREFORBENCHMARK 5
 
 - (void)processVideoSampleBuffer:(CMSampleBufferRef)sampleBuffer;


### PR DESCRIPTION
As outlined in this Issue #287 (https://github.com/BradLarson/GPUImage/issues/287), forceProcessingAtSize can cause some undesired effects when used multiple times. This commit fixes these issues.

In addition to this, it is now possible to access the AVCaptureConnection of a GPUImageVideoCamera, which allows for more fine-grained control such as toggling video stabilization, zoom factor, and enabling/disabling the entire connection.
