### PR TITLE
Leak in GPUImageRawDataOutput

### DIFF
--- a/framework/Source/GPUImageRawDataOutput.m
+++ b/framework/Source/GPUImageRawDataOutput.m
@@ -173,6 +173,7 @@
         glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
         
         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, CVOpenGLESTextureGetName(renderTexture), 0);
+        CFRelease(renderTexture);
     }
     else
     {


### PR DESCRIPTION
There appears to be a minor memory leak in GPUImageRawDataOutput
