### PR TITLE
Add setting to make GPUImageMovie respect an AVAsset's framerate.

### DIFF
--- a/framework/Source/GPUImageMovie.h
+++ b/framework/Source/GPUImageMovie.h
@@ -9,6 +9,7 @@
 
 @property (readwrite, retain) AVAsset *asset;
 @property(readwrite, retain) NSURL *url;
+@property(readwrite, assign) BOOL *respectFrameRate;
 
 /** This enables the benchmarking mode, which logs out instantaneous and average frame times to the console
  */


### PR DESCRIPTION
Add respectFrameRate property to GPUImageMovie. When this property is set to yes, GPUImageMovie will try to respect the AVAsset's nominal
framerate. It may go slower due to cpu load, but it won't go faster.

This is useful when e.g. using a GPUImageMovie to chromakeyblend with videocamera input.
