### PR TITLE
The GrayscaleFilter wasn't respecting the alpha channel

### DIFF
--- a/framework/Source/GPUImageGrayscaleFilter.m
+++ b/framework/Source/GPUImageGrayscaleFilter.m
@@ -14,9 +14,10 @@ NSString *const kGPUImageLuminanceFragmentShaderString = SHADER_STRING
  
  void main()
  {
-     float luminance = dot(texture2D(inputImageTexture, textureCoordinate).rgb, W);
+     lowp vec4 textureColor = texture2D(inputImageTexture, textureCoordinate);
+     float luminance = dot(textureColor.rgb, W);
      
-     gl_FragColor = vec4(vec3(luminance), 1.0);
+     gl_FragColor = vec4(vec3(luminance), textureColor.a);
  }
 );
 

--- a/framework/Source/GPUImageMotionDetector.m
+++ b/framework/Source/GPUImageMotionDetector.m
@@ -25,7 +25,7 @@ NSString *const kGPUImageMotionComparisonFragmentShaderString = SHADER_STRING
 
 @implementation GPUImageMotionDetector
 
-@synthesize lowPassFilterStrength;
+@synthesize lowPassFilterStrength, motionDetectionBlock;
 
 #pragma mark -
 #pragma mark Initialization and teardown


### PR DESCRIPTION
Hi, 

I found your library and I'm testing it for a project. I discovered that the GrayscaleFilter doesn't respect the alpha channel when applying it to a transparent/semi-transparent image. I did a minor change to the filter. 

Your library seems great! I still have to test it more but it looks like it does everything I need. 

Cheers!

Jorge.
