### PR TITLE
Tone curve filter initializing suggestion

### DIFF
--- a/framework/Source/GPUImageToneCurveFilter.h
+++ b/framework/Source/GPUImageToneCurveFilter.h
@@ -8,14 +8,16 @@
 @property(readwrite, nonatomic, copy) NSArray *rgbCompositeControlPoints;
 
 // Initialization and teardown
-- (id)initWithACV:(NSString*)curveFile;
+- (id)initWithACV:(NSString*)curveFilename;
+- (id)initWithACVURL:(NSURL*)curveFileURL;
 
 // This lets you set all three red, green, and blue tone curves at once.
 // NOTE: Deprecated this function because this effect can be accomplished
 // using the rgbComposite channel rather then setting all 3 R, G, and B channels.
 - (void)setRGBControlPoints:(NSArray *)points DEPRECATED_ATTRIBUTE;
 
-- (void)setPointsWithACV:(NSString*)curveFile;
+- (void)setPointsWithACV:(NSString*)curveFilename;
+- (void)setPointsWithACVURL:(NSURL*)curveFileURL;
 
 // Curve calculation
 - (NSMutableArray *)getPreparedSplineCurve:(NSArray *)points;


### PR DESCRIPTION
Currently, `GPUImageToneCurveFilter` is initialized with acv file name, and filter itself construct filepath from it assuming acv file is located in root of Documents directory. In case this file is stored somewhere else — there is absolutely no way to init this filter form it. My suggestion is to provide API for the user to be able to create filter from explicit fileURL. 
