### PR TITLE
prevent crash when captureStillImageAsynchronouslyFromConnection yields an error

### DIFF
--- a/framework/Source/GPUImageStillCamera.m
+++ b/framework/Source/GPUImageStillCamera.m
@@ -107,6 +107,12 @@ void GPUImageCreateResizedSampleBuffer(CVPixelBufferRef cameraFrame, CGSize fina
 
     [photoOutput captureStillImageAsynchronouslyFromConnection:[[photoOutput connections] objectAtIndex:0] completionHandler:^(CMSampleBufferRef imageSampleBuffer, NSError *error) {
 
+        if(imageSampleBuffer == NULL){
+            dispatch_semaphore_signal(frameRenderingSemaphore);
+            block(nil, error);
+            return;
+        }
+
         // For now, resize photos to fix within the max texture size of the GPU
         CVImageBufferRef cameraFrame = CMSampleBufferGetImageBuffer(imageSampleBuffer);
         
@@ -150,6 +156,12 @@ void GPUImageCreateResizedSampleBuffer(CVPixelBufferRef cameraFrame, CGSize fina
 
     [photoOutput captureStillImageAsynchronouslyFromConnection:[[photoOutput connections] objectAtIndex:0] completionHandler:^(CMSampleBufferRef imageSampleBuffer, NSError *error) {
 //        reportAvailableMemoryForGPUImage(@"Before filter processing");
+
+        if(imageSampleBuffer == NULL){
+            dispatch_semaphore_signal(frameRenderingSemaphore);
+            block(nil, error);
+            return;
+        }
 
         // For now, resize photos to fix within the max texture size of the GPU
         CVImageBufferRef cameraFrame = CMSampleBufferGetImageBuffer(imageSampleBuffer);
@@ -205,7 +217,13 @@ void GPUImageCreateResizedSampleBuffer(CVPixelBufferRef cameraFrame, CGSize fina
     dispatch_semaphore_wait(frameRenderingSemaphore, DISPATCH_TIME_FOREVER);
 
     [photoOutput captureStillImageAsynchronouslyFromConnection:[[photoOutput connections] objectAtIndex:0] completionHandler:^(CMSampleBufferRef imageSampleBuffer, NSError *error) {
-        
+
+        if(imageSampleBuffer == NULL){
+            dispatch_semaphore_signal(frameRenderingSemaphore);
+            block(nil, error);
+            return;
+        }
+
         // For now, resize photos to fix within the max texture size of the GPU
         CVImageBufferRef cameraFrame = CMSampleBufferGetImageBuffer(imageSampleBuffer);
         


### PR DESCRIPTION
If `captureStillImageAsynchronouslyFromConnection` calls back with an error in any of the capture methods of `GPUImageStillCamera` a crash occurs when `imageSampleBuffer`, now == `NULL` eventually gets passed to `CFRetain`. 

The change in this pull request checks if `imageSampleBuffer` is `NULL` and if so bails out of the methods accordingly. 
