### PR TITLE
Padding tone curve control points

### DIFF
--- a/framework/Source/GPUImageToneCurveFilter.m
+++ b/framework/Source/GPUImageToneCurveFilter.m
@@ -250,9 +250,19 @@ NSString *const kGPUImageToneCurveFragmentShaderString = SHADER_STRING
         CGPoint firstSplinePoint = [[splinePoints objectAtIndex:0] CGPointValue];
         
         if (firstSplinePoint.x > 0) {
-            for (int i=0; i <=firstSplinePoint.x; i++) {
-                CGPoint newCGPoint = CGPointMake(0, 0);
+            for (int i=firstSplinePoint.x; i >= 0; i--) {
+                CGPoint newCGPoint = CGPointMake(i, 0);
                 [splinePoints insertObject:[NSValue valueWithCGPoint:newCGPoint] atIndex:0];
+            }
+        }
+
+        // Insert points similarly at the end, if necessary.
+        CGPoint lastSplinePoint = [[splinePoints objectAtIndex:([splinePoints count] - 1)] CGPointValue];
+
+        if (lastSplinePoint.x < 255) {
+            for (int i = lastSplinePoint.x + 1; i <= 255; i++) {
+                CGPoint newCGPoint = CGPointMake(i, 255);
+                [splinePoints addObject:[NSValue valueWithCGPoint:newCGPoint]];
             }
         }
         


### PR DESCRIPTION
This patch corrects issues with some .acv files (where the composite control points begin at x > 0 and end at x < 255) that otherwise result in black images.
