### PR TITLE
proper error checking when opening ACV file in GPUImageToneCurveFilter

### DIFF
--- a/framework/Source/GPUImageToneCurveFilter.m
+++ b/framework/Source/GPUImageToneCurveFilter.m
@@ -41,7 +41,7 @@
         NSFileHandle* file = [NSFileHandle fileHandleForReadingFromURL:curveFilePathURL
                                                                  error:&error];
         
-        if (error)
+        if ((file == nil) || (error != nil))
         {
             NSLog(@"Failed to open file: %@", error);
             


### PR DESCRIPTION
fixed a bug in GPUImageToneCurveFilter that non-exists acv file will cause EXC_BAD_ACCESS
