### PR TITLE
Tone curves: prevent overflow

### DIFF
--- a/framework/Source/GPUImageToneCurveFilter.m
+++ b/framework/Source/GPUImageToneCurveFilter.m
@@ -436,9 +436,9 @@ NSString *const kGPUImageToneCurveFragmentShaderString = SHADER_STRING
             for (unsigned int currentCurveIndex = 0; currentCurveIndex < 256; currentCurveIndex++)
             {
                 // BGRA for upload to texture
-                toneCurveByteArray[currentCurveIndex * 4] = fmax(currentCurveIndex + [[_blueCurve objectAtIndex:currentCurveIndex] floatValue] + [[_rgbCompositeCurve objectAtIndex:currentCurveIndex] floatValue], 0);
-                toneCurveByteArray[currentCurveIndex * 4 + 1] = fmax(currentCurveIndex + [[_greenCurve objectAtIndex:currentCurveIndex] floatValue] + [[_rgbCompositeCurve objectAtIndex:currentCurveIndex] floatValue], 0);
-                toneCurveByteArray[currentCurveIndex * 4 + 2] = fmax(currentCurveIndex + [[_redCurve objectAtIndex:currentCurveIndex] floatValue] + [[_rgbCompositeCurve objectAtIndex:currentCurveIndex] floatValue], 0);
+                toneCurveByteArray[currentCurveIndex * 4] = fmin(fmax(currentCurveIndex + [[_blueCurve objectAtIndex:currentCurveIndex] floatValue] + [[_rgbCompositeCurve objectAtIndex:currentCurveIndex] floatValue], 0), 255);
+                toneCurveByteArray[currentCurveIndex * 4 + 1] = fmin(fmax(currentCurveIndex + [[_greenCurve objectAtIndex:currentCurveIndex] floatValue] + [[_rgbCompositeCurve objectAtIndex:currentCurveIndex] floatValue], 0), 255);
+                toneCurveByteArray[currentCurveIndex * 4 + 2] = fmin(fmax(currentCurveIndex + [[_redCurve objectAtIndex:currentCurveIndex] floatValue] + [[_rgbCompositeCurve objectAtIndex:currentCurveIndex] floatValue], 0), 255);
                 toneCurveByteArray[currentCurveIndex * 4 + 3] = 255;
             }
             


### PR DESCRIPTION
I have reproduced the same fault that was reported by Ordinary (https://github.com/BradLarson/GPUImage/issues/559) and I have applied their fix and successfully corrected it.

A similar fault was reported (https://github.com/BradLarson/GPUImage/issues/205) and that fix appears to have been included in the tone curves filter, however the overflow was still possible.

This is a curve that exhibits the problem. You will see colour overflows:

GPUImageToneCurveFilter *curves = [[GPUImageToneCurveFilter alloc] init];
    [curves setRgbCompositeControlPoints:@[[NSValue valueWithCGPoint:CGPointMake(.066666667, 0)],
     [NSValue valueWithCGPoint:CGPointMake(.741176471, 1.0)]]];

I believe the problem will appear with any curve that has a flat top like this.

The commit applies Ordinary's fix, corrects this and appears to match the behaviour in Photoshop (or similar).
