### PR TITLE
GPUImageTextureOutput had the wrong type for the texture property.

### DIFF
--- a/framework/Source/GPUImageTextureOutput.h
+++ b/framework/Source/GPUImageTextureOutput.h
@@ -9,7 +9,7 @@
 }
 
 @property(readwrite, unsafe_unretained, nonatomic) id<GPUImageTextureOutputDelegate> delegate;
-@property(readonly) GLint texture;
+@property(readonly) GLuint texture;
 @property(nonatomic) BOOL enabled;
 
 @end


### PR DESCRIPTION
Hi Brad,

A really tiny correction for GPUImageTextureOutput:

Was GLint should be GLuint.

cheers,
Karl
