### PR TITLE
Reduce code duplication in capturePhotoAs* methods of GPUImageStillCamera

### DIFF
--- a/framework/Source/GPUImageStillCamera.m
+++ b/framework/Source/GPUImageStillCamera.m
@@ -177,8 +177,12 @@ void GPUImageCreateResizedSampleBuffer(CVPixelBufferRef cameraFrame, CGSize fina
 {
     dispatch_semaphore_wait(frameRenderingSemaphore, DISPATCH_TIME_FOREVER);
 
-    [photoOutput captureStillImageAsynchronouslyFromConnection:[[photoOutput connections] objectAtIndex:0] completionHandler:^(CMSampleBufferRef imageSampleBuffer, NSError *error) {
+    if(photoOutput.isCapturingStillImage){
+        block([NSError errorWithDomain:AVFoundationErrorDomain code:AVErrorMaximumStillImageCaptureRequestsExceeded userInfo:nil]);
+        return;
+    }
 
+    [photoOutput captureStillImageAsynchronouslyFromConnection:[[photoOutput connections] objectAtIndex:0] completionHandler:^(CMSampleBufferRef imageSampleBuffer, NSError *error) {
         if(imageSampleBuffer == NULL){
             block(error);
             return;


### PR DESCRIPTION
The first commit is my best attempt at refactoring to reduce code duplication in all the `capturePhotoAs*` methods of `GPUImageStillCamera`. In my testing the behavior and memory management behave the same as before. If someone has a better way to do this, I'm happy to help out.

The latter commit adds an extra check to preempt trying to capture a still while one is already in the process of being captured.  The behavior to the code calling `capturePhotoAs*` should be the same (an error is returned to the block). The benefit of doing the check upfront is that the `frameRenderingSemaphore` semaphore gets released and the block gets called immediately instead of waiting to get an async error back from `captureStillImageAsynchronouslyFromConnection`.
