### PR TITLE
top left anchor point property for GPUImageTransformFilter

### DIFF
--- a/framework/Source/GPUImageTransformFilter.h
+++ b/framework/Source/GPUImageTransformFilter.h
@@ -13,4 +13,7 @@
 // This applies the transform to the raw frame data if set to YES, the default of NO takes the aspect ratio of the image input into account when rotating
 @property(readwrite, nonatomic) BOOL ignoreAspectRatio;
 
+// sets the anchor point to top left corner
+@property(readwrite, nonatomic) BOOL anchorTopLeft;
+
 @end

--- a/framework/Source/GPUImageTransformFilter.m
+++ b/framework/Source/GPUImageTransformFilter.m
@@ -2,13 +2,13 @@
 
 NSString *const kGPUImageTransformVertexShaderString = SHADER_STRING
 (
- attribute vec4 position;
- attribute vec4 inputTextureCoordinate;
+ attribute highp vec4 position;
+ attribute highp vec4 inputTextureCoordinate;
  
  uniform mat4 transformMatrix;
  uniform mat4 orthographicMatrix;
  
- varying vec2 textureCoordinate;
+ varying highp vec2 textureCoordinate;
  
  void main()
  {
@@ -22,6 +22,7 @@ NSString *const kGPUImageTransformVertexShaderString = SHADER_STRING
 @synthesize affineTransform;
 @synthesize transform3D = _transform3D;
 @synthesize ignoreAspectRatio = _ignoreAspectRatio;
+@synthesize anchorTopLeft = _anchorTopLeft;
 
 #pragma mark -
 #pragma mark Initialization and teardown
@@ -53,22 +54,27 @@ NSString *const kGPUImageTransformVertexShaderString = SHADER_STRING
     GLfloat ty = - (top + bottom) / (top - bottom);
     GLfloat tz = - (far + near) / (far - near);
     
-	tx=-1.0f;
-	ty=-1.0f;
+	float scale = 2.0f;
+	if (_anchorTopLeft)
+	{
+		scale = 4.0f;
+		tx=-1.0f;
+		ty=-1.0f;
+	}
 	
-    matrix[0] = 4.0f / r_l;
+    matrix[0] = scale / r_l;
     matrix[1] = 0.0f;
     matrix[2] = 0.0f;
     matrix[3] = tx;
     
     matrix[4] = 0.0f;
-    matrix[5] = 4.0f / t_b;
+    matrix[5] = scale / t_b;
     matrix[6] = 0.0f;
     matrix[7] = ty;
     
     matrix[8] = 0.0f;
     matrix[9] = 0.0f;
-    matrix[10] = 4.0f / f_n;
+    matrix[10] = scale / f_n;
     matrix[11] = tz;
     
     matrix[12] = 0.0f;
@@ -146,12 +152,26 @@ NSString *const kGPUImageTransformVertexShaderString = SHADER_STRING
     CGFloat normalizedHeight = currentFBOSize.height / currentFBOSize.width;
     
     GLfloat adjustedVertices[] = {
+        -1.0f, -normalizedHeight,
+        1.0f, -normalizedHeight,
+        -1.0f,  normalizedHeight,
+        1.0f,  normalizedHeight,
+    };
+    static const GLfloat squareVertices[] = {
+        -1.0f, -1.0f,
+        1.0f, -1.0f,
+        -1.0f,  1.0f,
+        1.0f,  1.0f,
+    };
+
+	GLfloat adjustedVerticesAnchorTL[] = {
         0.0f, 0.0f,
         1.0f, 0.0f,
         0.0f,  normalizedHeight,
         1.0f,  normalizedHeight,
     };
-    static const GLfloat squareVertices[] = {
+
+    static const GLfloat squareVerticesAnchorTL[] = {
         0.0f, 0.0f,
         1.0f, 0.0f,
         0.0f,  1.0f,
@@ -160,11 +180,25 @@ NSString *const kGPUImageTransformVertexShaderString = SHADER_STRING
 
     if (_ignoreAspectRatio)
     {
-        [self renderToTextureWithVertices:squareVertices textureCoordinates:[[self class] textureCoordinatesForRotation:inputRotation] sourceTexture:filterSourceTexture];    
+		if (_anchorTopLeft)
+		{
+			[self renderToTextureWithVertices:squareVerticesAnchorTL textureCoordinates:[[self class] textureCoordinatesForRotation:inputRotation] sourceTexture:filterSourceTexture];
+		}
+		else
+		{
+			[self renderToTextureWithVertices:squareVertices textureCoordinates:[[self class] textureCoordinatesForRotation:inputRotation] sourceTexture:filterSourceTexture];
+		}
     }
     else
     {
-        [self renderToTextureWithVertices:adjustedVertices textureCoordinates:[[self class] textureCoordinatesForRotation:inputRotation] sourceTexture:filterSourceTexture];    
+		if (_anchorTopLeft)
+		{
+			[self renderToTextureWithVertices:adjustedVerticesAnchorTL textureCoordinates:[[self class] textureCoordinatesForRotation:inputRotation] sourceTexture:filterSourceTexture];
+		}
+		else
+		{
+			[self renderToTextureWithVertices:adjustedVertices textureCoordinates:[[self class] textureCoordinatesForRotation:inputRotation] sourceTexture:filterSourceTexture];
+		}
     }
     
     [self informTargetsAboutNewFrameAtTime:frameTime];
@@ -217,6 +251,12 @@ NSString *const kGPUImageTransformVertexShaderString = SHADER_STRING
     {
         [self setupFilterForSize:[self sizeOfFBO]];
     }
+}
+
+- (void)setAnchorTopLeft:(BOOL)newValue
+{
+	_anchorTopLeft = newValue;
+	[self setIgnoreAspectRatio:_ignoreAspectRatio];
 }
 
 @end


### PR DESCRIPTION
Added anchorTopLeft property to GPUImageTransformFilter. This allows better compability when used with CATransform3D. (See issue #224: https://github.com/BradLarson/GPUImage/issues/224)
