### PR TITLE
added anchorTopLeft property to GPUImageTransformFilter

### DIFF
--- a/framework/Source/GPUImageTransformFilter.h
+++ b/framework/Source/GPUImageTransformFilter.h
@@ -13,4 +13,7 @@
 // This applies the transform to the raw frame data if set to YES, the default of NO takes the aspect ratio of the image input into account when rotating
 @property(readwrite, nonatomic) BOOL ignoreAspectRatio;
 
+// sets the anchor point to top left corner
+@property(readwrite, nonatomic) BOOL anchorTopLeft;
+
 @end


### PR DESCRIPTION
The added anchorTopLeft property provides better compatibility when using the GPUImageTransformFilter wit a CATransform3d. See issue #224 (https://github.com/BradLarson/GPUImage/issues/224).
