### PR TITLE
added pixelFormat property to raw data input

### DIFF
--- a/framework/Source/GPUImageRawDataInput.h
+++ b/framework/Source/GPUImageRawDataInput.h
@@ -2,7 +2,12 @@
 
 // The bytes passed into this input are not copied or retained, but you are free to deallocate them after they are used by this filter.
 // The bytes are uploaded and stored within a texture, so nothing is kept locally.
-// Input bytes are assumed to be in BGRA format.
+// The default format for input bytes is GPUPixelFormatBGRA, unless specified with pixelFormat:
+
+typedef enum {
+	GPUPixelFormatBGRA = GL_BGRA,
+	GPUPixelFormatRGBA = GL_RGBA
+} GPUPixelFormat;
 
 @interface GPUImageRawDataInput : GPUImageOutput
 {
@@ -13,6 +18,11 @@
 
 // Initialization and teardown
 - (id)initWithBytes:(GLubyte *)bytesToUpload size:(CGSize)imageSize;
+- (id)initWithBytes:(GLubyte *)bytesToUpload size:(CGSize)imageSize pixelFormat:(GPUPixelFormat)pixelFormat;
+
+/** Input data pixel format
+ */
+@property (readwrite, nonatomic) GPUPixelFormat pixelFormat;
 
 // Image rendering
 - (void)updateDataFromBytes:(GLubyte *)bytesToUpload size:(CGSize)imageSize;

--- a/framework/Source/GPUImageRawDataInput.m
+++ b/framework/Source/GPUImageRawDataInput.m
@@ -6,10 +6,22 @@
 
 @implementation GPUImageRawDataInput
 
+@synthesize pixelFormat = _pixelFormat;
+
 #pragma mark -
 #pragma mark Initialization and teardown
 
 - (id)initWithBytes:(GLubyte *)bytesToUpload size:(CGSize)imageSize;
+{
+    if (!(self = [self initWithBytes:bytesToUpload size:imageSize pixelFormat:GPUPixelFormatBGRA]))
+    {
+		return nil;
+    }
+	
+	return self;
+}
+
+- (id)initWithBytes:(GLubyte *)bytesToUpload size:(CGSize)imageSize pixelFormat:(GPUPixelFormat)pixelFormat;
 {
     if (!(self = [super init]))
     {
@@ -19,6 +31,7 @@
 	dataUpdateSemaphore = dispatch_semaphore_create(1);
 
     uploadedImageSize = imageSize;
+	self.pixelFormat = pixelFormat;
         
     [self uploadBytes:bytesToUpload];
     
@@ -43,7 +56,7 @@
 	[self initializeOutputTextureIfNeeded];
 
     glBindTexture(GL_TEXTURE_2D, outputTexture);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, (int)uploadedImageSize.width, (int)uploadedImageSize.height, 0, GL_BGRA, GL_UNSIGNED_BYTE, bytesToUpload);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, (int)uploadedImageSize.width, (int)uploadedImageSize.height, 0, (GLint)_pixelFormat, GL_UNSIGNED_BYTE, bytesToUpload);
 }
 
 - (void)updateDataFromBytes:(GLubyte *)bytesToUpload size:(CGSize)imageSize;


### PR DESCRIPTION
Ability to specify input data format (BGRA or RGBA). Default behavior unchanged (uses BGRA).

Constants:

```
typedef enum {
    GPUPixelFormatBGRA = GL_BGRA,
    GPUPixelFormatRGBA = GL_RGBA
} GPUPixelFormat;
```

Property:

```
@property (readwrite, nonatomic) GPUPixelFormat pixelFormat;
```

Additional init method:

```
- (id)initWithBytes:(GLubyte *)bytesToUpload size:(CGSize)imageSize pixelFormat:(GPUPixelFormat)pixelFormat;

```
