### PR TITLE
Add support for 3 channel and floating point textures.

### DIFF
--- a/framework/Source/GPUImageRawDataInput.h
+++ b/framework/Source/GPUImageRawDataInput.h
@@ -3,11 +3,18 @@
 // The bytes passed into this input are not copied or retained, but you are free to deallocate them after they are used by this filter.
 // The bytes are uploaded and stored within a texture, so nothing is kept locally.
 // The default format for input bytes is GPUPixelFormatBGRA, unless specified with pixelFormat:
+// The default type for input bytes is GPUPixelTypeUByte, unless specified with pixelType:
 
 typedef enum {
 	GPUPixelFormatBGRA = GL_BGRA,
-	GPUPixelFormatRGBA = GL_RGBA
+	GPUPixelFormatRGBA = GL_RGBA,
+	GPUPixelFormatRGB = GL_RGB
 } GPUPixelFormat;
+
+typedef enum {
+	GPUPixelTypeUByte = GL_UNSIGNED_BYTE,
+	GPUPixelTypeFloat = GL_FLOAT
+} GPUPixelType;
 
 @interface GPUImageRawDataInput : GPUImageOutput
 {
@@ -19,10 +26,12 @@ typedef enum {
 // Initialization and teardown
 - (id)initWithBytes:(GLubyte *)bytesToUpload size:(CGSize)imageSize;
 - (id)initWithBytes:(GLubyte *)bytesToUpload size:(CGSize)imageSize pixelFormat:(GPUPixelFormat)pixelFormat;
+- (id)initWithBytes:(GLubyte *)bytesToUpload size:(CGSize)imageSize pixelFormat:(GPUPixelFormat)pixelFormat type:(GPUPixelType)pixelType;
 
 /** Input data pixel format
  */
 @property (readwrite, nonatomic) GPUPixelFormat pixelFormat;
+@property (readwrite, nonatomic) GPUPixelType   pixelType;
 
 // Image rendering
 - (void)updateDataFromBytes:(GLubyte *)bytesToUpload size:(CGSize)imageSize;

--- a/framework/Source/GPUImageRawDataInput.m
+++ b/framework/Source/GPUImageRawDataInput.m
@@ -7,13 +7,14 @@
 @implementation GPUImageRawDataInput
 
 @synthesize pixelFormat = _pixelFormat;
+@synthesize pixelType = _pixelType;
 
 #pragma mark -
 #pragma mark Initialization and teardown
 
 - (id)initWithBytes:(GLubyte *)bytesToUpload size:(CGSize)imageSize;
 {
-    if (!(self = [self initWithBytes:bytesToUpload size:imageSize pixelFormat:GPUPixelFormatBGRA]))
+    if (!(self = [self initWithBytes:bytesToUpload size:imageSize pixelFormat:GPUPixelFormatBGRA type:GPUPixelTypeUByte]))
     {
 		return nil;
     }
@@ -22,6 +23,16 @@
 }
 
 - (id)initWithBytes:(GLubyte *)bytesToUpload size:(CGSize)imageSize pixelFormat:(GPUPixelFormat)pixelFormat;
+{
+    if (!(self = [self initWithBytes:bytesToUpload size:imageSize pixelFormat:pixelFormat type:GPUPixelTypeUByte]))
+    {
+		return nil;
+    }
+	
+	return self;
+}
+
+- (id)initWithBytes:(GLubyte *)bytesToUpload size:(CGSize)imageSize pixelFormat:(GPUPixelFormat)pixelFormat type:(GPUPixelType)pixelType;
 {
     if (!(self = [super init]))
     {
@@ -32,6 +43,7 @@
 
     uploadedImageSize = imageSize;
 	self.pixelFormat = pixelFormat;
+	self.pixelType = pixelType;
         
     [self uploadBytes:bytesToUpload];
     
@@ -56,7 +68,7 @@
 	[self initializeOutputTextureIfNeeded];
 
     glBindTexture(GL_TEXTURE_2D, outputTexture);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, (int)uploadedImageSize.width, (int)uploadedImageSize.height, 0, (GLint)_pixelFormat, GL_UNSIGNED_BYTE, bytesToUpload);
+    glTexImage2D(GL_TEXTURE_2D, 0, _pixelFormat==GPUPixelFormatRGB ? GL_RGB : GL_RGBA, (int)uploadedImageSize.width, (int)uploadedImageSize.height, 0, (GLint)_pixelFormat, (GLenum)_pixelType, bytesToUpload);
 }
 
 - (void)updateDataFromBytes:(GLubyte *)bytesToUpload size:(CGSize)imageSize;


### PR DESCRIPTION
Add a method to allow us to specify the data format in GPUImageRawDataInput. Right now we support unsigned byte and float. Also allow for RGB images.
