### PR TITLE
GPUImageSolidColorGenerator: fix setColor:(GPUVector4)newValue method im...

### DIFF
--- a/framework/Source/GPUImageSolidColorGenerator.m
+++ b/framework/Source/GPUImageSolidColorGenerator.m
@@ -60,7 +60,7 @@ NSString *const kGPUSolidColorFragmentShaderString = SHADER_STRING
 
 - (void)setColor:(GPUVector4)newValue;
 {
-	[self setColorRed:_color.one green:_color.two blue:_color.three alpha:_color.four];
+	[self setColorRed:newValue.one green:newValue.two blue:newValue.three alpha:newValue.four];
 }
 
 - (void)setColorRed:(GLfloat)redComponent green:(GLfloat)greenComponent blue:(GLfloat)blueComponent alpha:(GLfloat)alphaComponent;


### PR DESCRIPTION
Simple fix to the setColor:(GPUVector4) method in GPUImageSolorColorGenerator. A mistake in the implementation meant that the newValue passed into this method was never used!
