### PR TITLE
GPUImageVideoCamera: the delegate shouldn't be retained

### DIFF
--- a/framework/Source/GPUImageVideoCamera.h
+++ b/framework/Source/GPUImageVideoCamera.h
@@ -31,7 +31,7 @@
     GPUImageRotationMode outputRotation;
     dispatch_semaphore_t frameRenderingSemaphore;
 
-    id<GPUImageVideoCameraDelegate> _delegate;
+    __unsafe_unretained id<GPUImageVideoCameraDelegate> _delegate;
 }
 
 /// The AVCaptureSession used to capture from the camera
@@ -61,7 +61,7 @@
 /// These properties determine whether or not the two camera orientations should be mirrored. By default, both are NO.
 @property(readwrite, nonatomic) BOOL horizontallyMirrorFrontFacingCamera, horizontallyMirrorRearFacingCamera;
 
-@property(nonatomic, retain) id<GPUImageVideoCameraDelegate> delegate;
+@property(nonatomic, assign) id<GPUImageVideoCameraDelegate> delegate;
 
 /// @name Initialization and teardown
 


### PR DESCRIPTION
Retaining a delegate doesn't follow the usual pattern of delegates and thus could result in a retain cycle. I have changed the delegate to be __unsafe_unretained.
