### PR TITLE
GPUImageToneCurveFilter: initWithACVData

### DIFF
--- a/framework/Source/GPUImageToneCurveFilter.h
+++ b/framework/Source/GPUImageToneCurveFilter.h
@@ -8,6 +8,8 @@
 @property(readwrite, nonatomic, copy) NSArray *rgbCompositeControlPoints;
 
 // Initialization and teardown
+- (id)initWithACVData:(NSData*)data;
+
 - (id)initWithACV:(NSString*)curveFilename;
 - (id)initWithACVURL:(NSURL*)curveFileURL;
 


### PR DESCRIPTION
The idea behind this is that the .acv files should not be stored in the app bundle (can be copied easily). Acv file is small and can be stored as const string data.
