### PR TITLE
Added cancelWriting method to MovieWriter

### DIFF
--- a/framework/Source/GPUImageMovieWriter.h
+++ b/framework/Source/GPUImageMovieWriter.h
@@ -55,6 +55,7 @@ extern NSString *const kGPUImageColorSwizzlingFragmentShaderString;
 - (void)startRecording;
 - (void)startRecordingInOrientation:(CGAffineTransform)orientationTransform;
 - (void)finishRecording;
+- (void)cancelRecording;
 - (void)processAudioBuffer:(CMSampleBufferRef)audioBuffer;
 - (void)enableSynchronizationCallbacks;
 

--- a/framework/Source/GPUImageMovieWriter.m
+++ b/framework/Source/GPUImageMovieWriter.m
@@ -245,6 +245,21 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
 	[self startRecording];
 }
 
+- (void)cancelRecording;
+{
+    if (assetWriter.status == AVAssetWriterStatusCompleted)
+    {
+        return;
+    }
+    
+    isRecording = NO;
+    runOnMainQueueWithoutDeadlocking(^{
+        [assetWriterVideoInput markAsFinished];
+        [assetWriterAudioInput markAsFinished];
+        [assetWriter cancelWriting];
+    });
+}
+
 - (void)finishRecording;
 {
     if (assetWriter.status == AVAssetWriterStatusCompleted)


### PR DESCRIPTION
Added simple wrapper for AVAssetWriter cancelWriting based on MovieWriter finishWriting in order to cancel a recording and avoid flushing the new file to disk.
