### PR TITLE
Fixes bug where filters with Lookup Filter wouldn't update when provided new input

### DIFF
--- a/framework/Source/GPUImageAmatorkaFilter.m
+++ b/framework/Source/GPUImageAmatorkaFilter.m
@@ -26,6 +26,11 @@
     return self;
 }
 
+-(void)prepareForImageCapture {
+    [lookupImageSource processImage];
+    [super prepareForImageCapture];
+}
+
 #pragma mark -
 #pragma mark Accessors
 

--- a/framework/Source/GPUImageMissEtikateFilter.m
+++ b/framework/Source/GPUImageMissEtikateFilter.m
@@ -26,6 +26,11 @@
     return self;
 }
 
+-(void)prepareForImageCapture {
+    [lookupImageSource processImage];
+    [super prepareForImageCapture];
+}
+
 #pragma mark -
 #pragma mark Accessors
 

--- a/framework/Source/GPUImageSoftEleganceFilter.m
+++ b/framework/Source/GPUImageSoftEleganceFilter.m
@@ -50,6 +50,12 @@
     return self;
 }
 
+-(void)prepareForImageCapture {
+    [lookupImageSource1 processImage];
+    [lookupImageSource2 processImage];
+    [super prepareForImageCapture];
+}
+
 #pragma mark -
 #pragma mark Accessors
 


### PR DESCRIPTION
Fix defects as described in issue #654 - filters using a lookup filter would not update with new input.

When a filter with a lookup filter (eg MissEtikate or SoftElegance) exists in a chain and was provided new input, it would not update. Updates occurring through changing actual inputs from another filter or changing existing filters with mutable parameters wold not compel the lookup filter to re-process the input data.
