### PR TITLE
Add pause/resume method to GPUImageMovieWriter

### DIFF
--- a/framework/Source/GPUImageMovieWriter.h
+++ b/framework/Source/GPUImageMovieWriter.h
@@ -54,6 +54,8 @@ extern NSString *const kGPUImageColorSwizzlingFragmentShaderString;
 // Movie recording
 - (void)startRecording;
 - (void)startRecordingInOrientation:(CGAffineTransform)orientationTransform;
+- (void)pauseRecording;
+- (void)resumeRecording;
 - (void)finishRecording;
 - (void)finishRecordingWithCompletionHandler:(void (^)(void))handler;
 - (void)cancelRecording;


### PR DESCRIPTION
I'm not sure this is right way.  While pausing recording, remember frame time range. After resume, subtract stored range from new frame time.
