### PR TITLE
Add `error` parameter to `finishWriting…` handler block

### DIFF
--- a/framework/Source/GPUImageMovieWriter.h
+++ b/framework/Source/GPUImageMovieWriter.h
@@ -55,7 +55,7 @@ extern NSString *const kGPUImageColorSwizzlingFragmentShaderString;
 - (void)startRecording;
 - (void)startRecordingInOrientation:(CGAffineTransform)orientationTransform;
 - (void)finishRecording;
-- (void)finishRecordingWithCompletionHandler:(void (^)(void))handler;
+- (void)finishRecordingWithCompletionHandler:(void(^)(NSError *error))handler;
 - (void)cancelRecording;
 - (void)processAudioBuffer:(CMSampleBufferRef)audioBuffer;
 - (void)enableSynchronizationCallbacks;

--- a/framework/Source/GPUImageMovieWriter.m
+++ b/framework/Source/GPUImageMovieWriter.m
@@ -265,7 +265,7 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
     [self finishRecordingWithCompletionHandler:nil];
 }
 
-- (void)finishRecordingWithCompletionHandler:(void (^)(void))handler;
+- (void)finishRecordingWithCompletionHandler:(void(^)(NSError *error))handler;
 {
     if (assetWriter.status == AVAssetWriterStatusCompleted)
     {
@@ -279,17 +279,19 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
 #if (!defined(__IPHONE_6_0) || (__IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_6_0))
         // Not iOS 6 SDK
         [assetWriter finishWriting];
-        if (handler) handler();
+        if (handler) handler(assetWriter.error);
 #else
         // iOS 6 SDK
         if ([assetWriter respondsToSelector:@selector(finishWritingWithCompletionHandler:)]) {
             // Running iOS 6
-            [assetWriter finishWritingWithCompletionHandler:(handler ?: ^{ })];
+            [assetWriter finishWritingWithCompletionHandler:^{
+                if (handler) handler(assetWriter.error);
+            }];
         }
         else {
             // Not running iOS 6
             [assetWriter finishWriting];
-            if (handler) handler();
+            if (handler) handler(assetWriter.error);
         }
 #endif
     });


### PR DESCRIPTION
Discussed in Pull Request #823.

I added `error` parameter to handler block of method `-[GPUImageMovieWriter finishWritingWithCompletionHandler:`. On successful write, the value is nil, on failure it contains error description.

The error is taken from `error` property of underlaying `AVAssetWriter`.
