### PR TITLE
Fix an issue that GPUImageMovie instance is retained by block object but not released

### DIFF
--- a/framework/Source/GPUImageMovie.m
+++ b/framework/Source/GPUImageMovie.m
@@ -106,7 +106,10 @@
     previousActualFrameTime = CFAbsoluteTimeGetCurrent();
   
     NSDictionary *inputOptions = [NSDictionary dictionaryWithObject:[NSNumber numberWithBool:YES] forKey:AVURLAssetPreferPreciseDurationAndTimingKey];
-    AVURLAsset *inputAsset = [[AVURLAsset alloc] initWithURL:self.url options:inputOptions];    
+    AVURLAsset *inputAsset = [[AVURLAsset alloc] initWithURL:self.url options:inputOptions];
+    
+    GPUImageMovie __block *blockSelf = self;
+    
     [inputAsset loadValuesAsynchronouslyForKeys:[NSArray arrayWithObject:@"tracks"] completionHandler: ^{
         NSError *error = nil;
         AVKeyValueStatus tracksStatus = [inputAsset statusOfValueForKey:@"tracks" error:&error];
@@ -114,8 +117,9 @@
         {
             return;
         }
-        self.asset = inputAsset;
-        [self processAsset];
+        blockSelf.asset = inputAsset;
+        [blockSelf processAsset];
+        blockSelf = nil;
     }];
 }
 


### PR DESCRIPTION
Recently I ran into memory warnings and at last crash after playing many GPUImageMovie objects.

By doing profiling in Instruments (referring to http://stackoverflow.com/a/12286739/1241690), I found that in GPUImageMovie.m, "self" is implicitly retained by the block object in "startProcessing" method.

According to the "Use Lifetime Qualifiers to Avoid Strong Reference Cycles" section in "Transitioning to ARC Release Notes" (http://developer.apple.com/library/mac/releasenotes/ObjectiveC/RN-TransitioningToARC/Introduction/Introduction.html#//apple_ref/doc/uid/TP40011226-CH1-SW4), this can be fixed using "__block", as the changes in the pull request.
