### PR TITLE
 	fixes iOS 6.0 deprecation warning on dispatch_get_current_queue() 

### DIFF
--- a/framework/Source/GPUImageOpenGLESContext.h
+++ b/framework/Source/GPUImageOpenGLESContext.h
@@ -16,6 +16,7 @@ typedef enum { kGPUImageNoRotation, kGPUImageRotateLeft, kGPUImageRotateRight, k
 @property(readonly, nonatomic) dispatch_queue_t contextQueue;
 @property(readwrite, retain, nonatomic) GLProgram *currentShaderProgram;
 
++ (void *)contextKey;
 + (GPUImageOpenGLESContext *)sharedImageProcessingOpenGLESContext;
 + (dispatch_queue_t)sharedOpenGLESQueue;
 + (void)useImageProcessingContext;

--- a/framework/Source/GPUImageOpenGLESContext.m
+++ b/framework/Source/GPUImageOpenGLESContext.m
@@ -16,17 +16,25 @@
 @synthesize currentShaderProgram = _currentShaderProgram;
 @synthesize contextQueue = _contextQueue;
 
+static void *openGLESContextQueueKey;
+
 - (id)init;
 {
     if (!(self = [super init]))
     {
 		return nil;
     }
-        
+
+	openGLESContextQueueKey = &openGLESContextQueueKey;
     _contextQueue = dispatch_queue_create("com.sunsetlakesoftware.GPUImage.openGLESContextQueue", NULL);
+	dispatch_queue_set_specific(_contextQueue, openGLESContextQueueKey, (__bridge void *)self, NULL);
     shaderProgramCache = [[NSMutableDictionary alloc] init];
     
     return self;
+}
+
++ (void *)contextKey {
+	return openGLESContextQueueKey;
 }
 
 // Based on Colin Wheeler's example here: http://cocoasamurai.blogspot.com/2011/04/singletons-your-doing-them-wrong.html

--- a/framework/Source/GPUImageOutput.m
+++ b/framework/Source/GPUImageOutput.m
@@ -19,11 +19,10 @@ void runSynchronouslyOnVideoProcessingQueue(void (^block)(void))
 {
     dispatch_queue_t videoProcessingQueue = [GPUImageOpenGLESContext sharedOpenGLESQueue];
     
-	if (dispatch_get_current_queue() == videoProcessingQueue)
+	if(dispatch_get_specific([GPUImageOpenGLESContext contextKey]))
 	{
 		block();
-	}
-	else
+	}else
 	{
 		dispatch_sync(videoProcessingQueue, block);
 	}
@@ -33,11 +32,10 @@ void runAsynchronouslyOnVideoProcessingQueue(void (^block)(void))
 {
     dispatch_queue_t videoProcessingQueue = [GPUImageOpenGLESContext sharedOpenGLESQueue];
     
-	if (dispatch_get_current_queue() == videoProcessingQueue)
+	if(dispatch_get_specific([GPUImageOpenGLESContext contextKey]))
 	{
 		block();
-	}
-	else
+	}else
 	{
 		dispatch_async(videoProcessingQueue, block);
 	}


### PR DESCRIPTION
utilizes the proposed alternatives:
dispatch_queue_set_specific()
dispatch_get_specific()
