### PR TITLE
Fix GPUImageTwoInputFilter to correctly reset itself

### DIFF
--- a/framework/Source/GPUImageTwoInputFilter.m
+++ b/framework/Source/GPUImageTwoInputFilter.m
@@ -143,7 +143,7 @@ NSString *const kGPUImageTwoInputTextureVertexShaderString = SHADER_STRING
     if (textureIndex == 0)
     {
         filterSourceTexture = newInputTexture;
-        hasSetFirstTexture = YES;
+        hasSetFirstTexture = (newInputTexture != 0);
     }
     else
     {


### PR DESCRIPTION
This addresses issue #687.

Its possible for `[GPUFilter setInputText:atIndex:]` to be called with `newInputTexture` set to `zero`. This is not a valid texture name, so this is effectively resetting the input texture. Since that's the case, `hasSetFirstTexture` should not always be `YES`.
