### PR TITLE
Fix filter resetting to ensure GPUImageTwoInputFilter is in good state

### DIFF
--- a/framework/Source/GPUImageOutput.m
+++ b/framework/Source/GPUImageOutput.m
@@ -177,8 +177,8 @@ void reportAvailableMemoryForGPUImage(NSString *tag)
     NSInteger textureIndexOfTarget = [[targetTextureIndices objectAtIndex:indexOfObject] integerValue];
 
     runSynchronouslyOnVideoProcessingQueue(^{
-        [targetToRemove setInputSize:CGSizeZero atIndex:textureIndexOfTarget];
         [targetToRemove setInputTexture:0 atIndex:textureIndexOfTarget];
+        [targetToRemove setInputSize:CGSizeZero atIndex:textureIndexOfTarget];
         [targetToRemove setTextureDelegate:nil atIndex:textureIndexOfTarget];
 		[targetToRemove setInputRotation:kGPUImageNoRotation atIndex:textureIndexOfTarget];
 
@@ -197,8 +197,8 @@ void reportAvailableMemoryForGPUImage(NSString *tag)
             NSInteger indexOfObject = [targets indexOfObject:targetToRemove];
             NSInteger textureIndexOfTarget = [[targetTextureIndices objectAtIndex:indexOfObject] integerValue];
             
-            [targetToRemove setInputSize:CGSizeZero atIndex:textureIndexOfTarget];
             [targetToRemove setInputTexture:0 atIndex:textureIndexOfTarget];
+            [targetToRemove setInputSize:CGSizeZero atIndex:textureIndexOfTarget];
             [targetToRemove setTextureDelegate:nil atIndex:textureIndexOfTarget];
             [targetToRemove setInputRotation:kGPUImageNoRotation atIndex:textureIndexOfTarget];
         }


### PR DESCRIPTION
GPUImageTwoInputFilter is not being reset properly, specifically `hasSetFirstTexture` is not being set back to `NO`. My previous patch attempted to fix this but did not take into account some subtleties. This patch fixes my original issue and also doesn't break the FilterShowcase app.

The reason for this issue, as I understand it, is that the meaning of GLUint zero in `[GPUImageInput setInputTexture:atIndex:]` is being overloaded as both "this is a placeholder, wait for the real value" and "reset the filter".

The first meaning comes into play when setting up. `[GPUImageOutput outputTexture]' is not yet initialized, but its still used as the filters' inputTexture. Then when it is initialized, the filters are notified via '[GPUImageOutput notifyTargetsAboutNewOutputTexture]`.

The second meaning is used in `[GPUImageOutput removeAllTargets]`.

My original fix broke the first case. For this new fix, I noticed that GPUImageTwoInputFilter resets itself in `setInputSize:atIndex:`, but this was being called in the wrong order so it would get reset and then immediately unreset. This patch fixes the call order.
