### PR TITLE
Added build.sh script to compile a universal library for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ BSD-style, with the full license available with the framework in License.txt.
 - Devices must have a camera to use camera-related functionality (obviously)
 - The framework uses automatic reference counting (ARC), but should support projects using both ARC and manual reference counting if added as a subproject as explained below. For manual reference counting applications targeting iOS 4.x, you'll need add -fobjc-arc to the Other Linker Flags for your application project.
 
+## Build iOS static library ##
+
+Execute `build.sh` to compile a universal library for iOS simulator/device. The produced library and header files are located at `build/Release-iphone`. You may also change the version of iOS SDK by specifying `IOSSDK_VER` in the `build.sh` (all available versions can be found using `xcodebuild -showsdks`).
+
 ## General architecture ##
 
 GPUImage uses OpenGL ES 2.0 shaders to perform image and video manipulation much faster than could be done in CPU-bound routines. However, it hides the complexity of interacting with the OpenGL ES API in a simplified Objective-C interface. This interface lets you define input sources for images and video, attach filters in a chain, and send the resulting processed image or video to the screen, to a UIImage, or to a movie on disk.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+IOSSDK_VER="6.1"
+
+# xcodebuild -showsdks
+
+cd framework
+xcodebuild -project GPUImage.xcodeproj -target GPUImage -configuration Release -sdk iphoneos${IOSSDK_VER} build
+xcodebuild -project GPUImage.xcodeproj -target GPUImage -configuration Release -sdk iphonesimulator${IOSSDK_VER} build
+cd ..
+
+cd build
+# for the fat lib file
+mkdir -p Release-iphone/lib
+xcrun -sdk iphoneos lipo -create Release-iphoneos/libGPUImage.a Release-iphonesimulator/libGPUImage.a -output Release-iphone/lib/libGPUImage.a
+xcrun -sdk iphoneos lipo -info Release-iphone/lib/libGPUImage.a
+# for header files
+mkdir -p Release-iphone/include
+cp ../framework/Source/*.h Release-iphone/include
+cp ../framework/Source/iOS/*.h Release-iphone/include


### PR DESCRIPTION
## Build iOS static library

Execute `build.sh` to compile a universal library for iOS simulator/device. The produced library and header files are located at `build/Release-iphone`. You may also change the version of iOS SDK by specifying `IOSSDK_VER` in the `build.sh` (all available versions can be found using `xcodebuild -showsdks`).
