### PR TITLE
Fixed issue #765

### DIFF
--- a/framework/Source/GPUImageMovie.h
+++ b/framework/Source/GPUImageMovie.h
@@ -40,6 +40,7 @@
 - (void)readNextAudioSampleFromOutput:(AVAssetReaderTrackOutput *)readerAudioTrackOutput;
 - (void)startProcessing;
 - (void)endProcessing;
+- (void)cancelProcessing;
 - (void)processMovieFrame:(CMSampleBufferRef)movieSampleBuffer; 
 
 @end

--- a/framework/Source/GPUImageMovie.m
+++ b/framework/Source/GPUImageMovie.m
@@ -361,4 +361,12 @@
     }
 }
 
+- (void)cancelProcessing
+{
+    if (reader) {
+        [reader cancelReading];
+    }
+    [self endProcessing];
+}
+
 @end

--- a/framework/Source/iOS/GPUImageMovieWriter.m
+++ b/framework/Source/iOS/GPUImageMovieWriter.m
@@ -267,7 +267,7 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
 
 - (void)finishRecordingWithCompletionHandler:(void (^)(void))handler;
 {
-    if (assetWriter.status == AVAssetWriterStatusCompleted)
+    if (assetWriter.status == AVAssetWriterStatusCompleted || assetWriter.status == AVAssetWriterStatusCancelled)
     {
         return;
     }


### PR DESCRIPTION
- Added 'cancelProcessing' method to GPUImageMovie to cancel an on-going video file processing.
- Added a check to cancelled status to 'finishRecordingWithCompletionHandler:' in GPUImageMovieWriter to detect if the writing was cancelled.
