### PR TITLE
Use GPUImageRawDataOutput cached bytes

### DIFF
--- a/framework/Source/GPUImageRawDataOutput.m
+++ b/framework/Source/GPUImageRawDataOutput.m
@@ -400,6 +400,9 @@
                 // GL_EXT_read_format_bgra
                 //            glReadPixels(0, 0, imageSize.width, imageSize.height, GL_BGRA_EXT, GL_UNSIGNED_BYTE, _rawBytesForImage);
             }
+          
+            hasReadFromTheCurrentFrame = YES;
+
         });
         
         return _rawBytesForImage;


### PR DESCRIPTION
Fix GPUImageRawDataOutput so that if the current frame has been read previously, the cached version is returned rather than reading the pixel buffer/texture cache each time
