### PR TITLE
Add convenience method to GPUImageFilterPipeline 

### DIFF
--- a/framework/Source/GPUImageFilterPipeline.h
+++ b/framework/Source/GPUImageFilterPipeline.h
@@ -23,6 +23,7 @@
 - (void) removeAllFilters;
 
 - (UIImage *) currentFilteredFrame;
+- (UIImage *) currentFilteredFrameWithOrientation:(UIImageOrientation)imageOrientation;
 - (CGImageRef) newCGImageFromCurrentFilteredFrame;
 - (CGImageRef) newCGImageFromCurrentFilteredFrameWithOrientation:(UIImageOrientation)imageOrientation;
 

--- a/framework/Source/GPUImageFilterPipeline.m
+++ b/framework/Source/GPUImageFilterPipeline.m
@@ -201,6 +201,10 @@
     return [(GPUImageFilter *)[_filters lastObject] imageFromCurrentlyProcessedOutput];
 }
 
+- (UIImage *)currentFilteredFrameWithOrientation:(UIImageOrientation)imageOrientation {
+  return [(GPUImageFilter *)[_filters lastObject] imageFromCurrentlyProcessedOutputWithOrientation:imageOrientation];
+}
+
 - (CGImageRef)newCGImageFromCurrentFilteredFrame {
     return [(GPUImageFilter *)[_filters lastObject] newCGImageFromCurrentlyProcessedOutput];
 }


### PR DESCRIPTION
A method for getting an UIImage with specific orientation seemed to be missing: 
- (UIImage *) currentFilteredFrameWithOrientation:(UIImageOrientation)imageOrientation; 
