### PR TITLE
Allow inverting colors for edge detection filters via property

### DIFF
--- a/framework/Source/GPUImagePrewittEdgeDetectionFilter.m
+++ b/framework/Source/GPUImagePrewittEdgeDetectionFilter.m
@@ -20,6 +20,7 @@ NSString *const kGPUImagePrewittFragmentShaderString = SHADER_STRING
  varying vec2 bottomRightTextureCoordinate;
  
  uniform sampler2D inputImageTexture;
+ uniform lowp float invertColor;
  
  void main()
  {
@@ -34,7 +35,7 @@ NSString *const kGPUImagePrewittFragmentShaderString = SHADER_STRING
      float h = -topLeftIntensity - topIntensity - topRightIntensity + bottomLeftIntensity + bottomIntensity + bottomRightIntensity;
      float v = -bottomLeftIntensity - leftIntensity - topLeftIntensity + bottomRightIntensity + rightIntensity + topRightIntensity;
      
-     float mag = length(vec2(h, v));
+     float mag = abs(length(vec2(h, v)) - invertColor);
      
      gl_FragColor = vec4(vec3(mag), 1.0);
  }
@@ -55,7 +56,8 @@ NSString *const kGPUImagePrewittFragmentShaderString = SHADER_STRING
  varying vec2 bottomRightTextureCoordinate;
  
  uniform sampler2D inputImageTexture;
- 
+ uniform float invertColor;
+
  void main()
  {
      float bottomLeftIntensity = texture2D(inputImageTexture, bottomLeftTextureCoordinate).r;
@@ -69,7 +71,7 @@ NSString *const kGPUImagePrewittFragmentShaderString = SHADER_STRING
      float h = -topLeftIntensity - topIntensity - topRightIntensity + bottomLeftIntensity + bottomIntensity + bottomRightIntensity;
      float v = -bottomLeftIntensity - leftIntensity - topLeftIntensity + bottomRightIntensity + rightIntensity + topRightIntensity;
      
-     float mag = length(vec2(h, v));
+     float mag = abs(length(vec2(h, v)) - invertColor);
      
      gl_FragColor = vec4(vec3(mag), 1.0);
  }

--- a/framework/Source/GPUImageSketchFilter.m
+++ b/framework/Source/GPUImageSketchFilter.m
@@ -21,6 +21,7 @@ NSString *const kGPUImageSketchFragmentShaderString = SHADER_STRING
  varying vec2 bottomRightTextureCoordinate;
  
  uniform sampler2D inputImageTexture;
+ uniform lowp float invertColor;
  
  void main()
  {
@@ -35,7 +36,7 @@ NSString *const kGPUImageSketchFragmentShaderString = SHADER_STRING
      float h = -topLeftIntensity - 2.0 * topIntensity - topRightIntensity + bottomLeftIntensity + 2.0 * bottomIntensity + bottomRightIntensity;
      float v = -bottomLeftIntensity - 2.0 * leftIntensity - topLeftIntensity + bottomRightIntensity + 2.0 * rightIntensity + topRightIntensity;
      
-     float mag = 1.0 - length(vec2(h, v));
+     float mag = abs(length(vec2(h, v)) - invertColor);
      
      gl_FragColor = vec4(vec3(mag), 1.0);
  }
@@ -56,6 +57,7 @@ NSString *const kGPUImageSketchFragmentShaderString = SHADER_STRING
  varying vec2 bottomRightTextureCoordinate;
  
  uniform sampler2D inputImageTexture;
+ uniform float invertColor;
  
  void main()
  {
@@ -70,7 +72,7 @@ NSString *const kGPUImageSketchFragmentShaderString = SHADER_STRING
      float h = -topLeftIntensity - 2.0 * topIntensity - topRightIntensity + bottomLeftIntensity + 2.0 * bottomIntensity + bottomRightIntensity;
      float v = -bottomLeftIntensity - 2.0 * leftIntensity - topLeftIntensity + bottomRightIntensity + 2.0 * rightIntensity + topRightIntensity;
      
-     float mag = 1.0 - length(vec2(h, v));
+     float mag = abs(length(vec2(h, v)) - invertColor);
      
      gl_FragColor = vec4(vec3(mag), 1.0);
  }
@@ -86,6 +88,7 @@ NSString *const kGPUImageSketchFragmentShaderString = SHADER_STRING
     {
 		return nil;
     }
+    self.invertColor = YES;
     
     return self;
 }

--- a/framework/Source/GPUImageSobelEdgeDetectionFilter.h
+++ b/framework/Source/GPUImageSobelEdgeDetectionFilter.h
@@ -2,12 +2,13 @@
 
 @interface GPUImageSobelEdgeDetectionFilter : GPUImageTwoPassFilter
 {
-    GLint texelWidthUniform, texelHeightUniform;
+    GLint texelWidthUniform, texelHeightUniform, invertColorUniform;
     BOOL hasOverriddenImageSizeFactor;
 }
 
 // The texel width and height factors tweak the appearance of the edges. By default, they match the inverse of the filter size in pixels
 @property(readwrite, nonatomic) CGFloat texelWidth; 
 @property(readwrite, nonatomic) CGFloat texelHeight; 
+@property(readwrite, nonatomic, assign) BOOL invertColor; // default is NO, set to YES to have white background with black borders
 
 @end

--- a/framework/Source/GPUImageSobelEdgeDetectionFilter.m
+++ b/framework/Source/GPUImageSobelEdgeDetectionFilter.m
@@ -21,6 +21,7 @@ NSString *const kGPUImageSobelEdgeDetectionFragmentShaderString = SHADER_STRING
  varying vec2 bottomRightTextureCoordinate;
 
  uniform sampler2D inputImageTexture;
+ uniform lowp float invertColor;
  
  void main()
  {
@@ -35,7 +36,7 @@ NSString *const kGPUImageSobelEdgeDetectionFragmentShaderString = SHADER_STRING
     float h = -topLeftIntensity - 2.0 * topIntensity - topRightIntensity + bottomLeftIntensity + 2.0 * bottomIntensity + bottomRightIntensity;
     float v = -bottomLeftIntensity - 2.0 * leftIntensity - topLeftIntensity + bottomRightIntensity + 2.0 * rightIntensity + topRightIntensity;
     
-    float mag = length(vec2(h, v));
+    float mag = abs(length(vec2(h, v)) - invertColor);
     
     gl_FragColor = vec4(vec3(mag), 1.0);
  }
@@ -56,6 +57,7 @@ NSString *const kGPUImageSobelEdgeDetectionFragmentShaderString = SHADER_STRING
  varying vec2 bottomRightTextureCoordinate;
  
  uniform sampler2D inputImageTexture;
+ uniform float invertColor;
  
  void main()
  {
@@ -70,7 +72,7 @@ NSString *const kGPUImageSobelEdgeDetectionFragmentShaderString = SHADER_STRING
      float h = -topLeftIntensity - 2.0 * topIntensity - topRightIntensity + bottomLeftIntensity + 2.0 * bottomIntensity + bottomRightIntensity;
      float v = -bottomLeftIntensity - 2.0 * leftIntensity - topLeftIntensity + bottomRightIntensity + 2.0 * rightIntensity + topRightIntensity;
      
-     float mag = length(vec2(h, v));
+     float mag = abs(length(vec2(h, v)) - invertColor);
      
      gl_FragColor = vec4(vec3(mag), 1.0);
  }
@@ -108,6 +110,8 @@ NSString *const kGPUImageSobelEdgeDetectionFragmentShaderString = SHADER_STRING
     
     texelWidthUniform = [secondFilterProgram uniformIndex:@"texelWidth"];
     texelHeightUniform = [secondFilterProgram uniformIndex:@"texelHeight"];
+    invertColorUniform = [secondFilterProgram uniformIndex:@"invertColor"];
+    self.invertColor = NO;
     
     return self;
 }
@@ -153,6 +157,13 @@ NSString *const kGPUImageSobelEdgeDetectionFragmentShaderString = SHADER_STRING
     _texelHeight = newValue;
 
     [self setFloat:_texelHeight forUniform:texelHeightUniform program:secondFilterProgram];
+}
+
+- (void)setInvertColor:(BOOL)invertColor
+{
+    _invertColor = invertColor;
+
+    [self setFloat:(invertColor ? 1.0f : 0.0f) forUniform:invertColorUniform program:secondFilterProgram];
 }
 
 @end

--- a/framework/Source/GPUImageSolidColorGenerator.m
+++ b/framework/Source/GPUImageSolidColorGenerator.m
@@ -4,22 +4,22 @@
 NSString *const kGPUSolidColorFragmentShaderString = SHADER_STRING
 (
  precision lowp float;
-
- varying highp vec2 textureCoordinate;
+ 
+ varying highp vec2 textureCoordinate; 
  uniform sampler2D inputImageTexture;
  uniform vec4 color;
  uniform float useExistingAlpha;
-
+ 
  void main()
  {
      lowp vec4 textureColor = texture2D(inputImageTexture, textureCoordinate);
      gl_FragColor = vec4(color.rgb, max(textureColor.a, 1.0 - useExistingAlpha));
  }
- );
+);
 #else
 NSString *const kGPUSolidColorFragmentShaderString = SHADER_STRING
 (
- varying vec2 textureCoordinate;
+ varying vec2 textureCoordinate; 
  uniform sampler2D inputImageTexture;
  uniform vec4 color;
  uniform float useExistingAlpha;
@@ -29,7 +29,7 @@ NSString *const kGPUSolidColorFragmentShaderString = SHADER_STRING
      vec4 textureColor = texture2D(inputImageTexture, textureCoordinate);
      gl_FragColor = vec4(color.rgb, max(textureColor.a, 1.0 - useExistingAlpha));
  }
- );
+);
 #endif
 
 @implementation GPUImageSolidColorGenerator
@@ -96,7 +96,7 @@ NSString *const kGPUSolidColorFragmentShaderString = SHADER_STRING
 {
     _useExistingAlpha = useExistingAlpha;
 
-    [self setInteger:(useExistingAlpha ? 1 : 0) forUniform:useExistingAlphaUniform program:filterProgram];
+    [self setFloat:(useExistingAlpha ? 1.0f : 0.0f) forUniform:useExistingAlphaUniform program:filterProgram];
 }
 
 @end

--- a/framework/Source/GPUImageThresholdEdgeDetectionFilter.m
+++ b/framework/Source/GPUImageThresholdEdgeDetectionFilter.m
@@ -22,6 +22,7 @@ NSString *const kGPUImageThresholdEdgeDetectionFragmentShaderString = SHADER_STR
  
  uniform sampler2D inputImageTexture;
  uniform lowp float threshold;
+ uniform lowp float invertColor;
  
  const highp vec3 W = vec3(0.2125, 0.7154, 0.0721);
  
@@ -38,7 +39,7 @@ NSString *const kGPUImageThresholdEdgeDetectionFragmentShaderString = SHADER_STR
      float h = -topLeftIntensity - 2.0 * topIntensity - topRightIntensity + bottomLeftIntensity + 2.0 * bottomIntensity + bottomRightIntensity;
      float v = -bottomLeftIntensity - 2.0 * leftIntensity - topLeftIntensity + bottomRightIntensity + 2.0 * rightIntensity + topRightIntensity;
      
-     float mag = length(vec2(h, v));
+     float mag = abs(length(vec2(h, v)) - invertColor);
      mag = step(threshold, mag);
      
      gl_FragColor = vec4(vec3(mag), 1.0);
@@ -61,6 +62,7 @@ NSString *const kGPUImageThresholdEdgeDetectionFragmentShaderString = SHADER_STR
  
  uniform sampler2D inputImageTexture;
  uniform float threshold;
+ uniform float invertColor;
  
  const vec3 W = vec3(0.2125, 0.7154, 0.0721);
  
@@ -77,7 +79,7 @@ NSString *const kGPUImageThresholdEdgeDetectionFragmentShaderString = SHADER_STR
      float h = -topLeftIntensity - 2.0 * topIntensity - topRightIntensity + bottomLeftIntensity + 2.0 * bottomIntensity + bottomRightIntensity;
      float v = -bottomLeftIntensity - 2.0 * leftIntensity - topLeftIntensity + bottomRightIntensity + 2.0 * rightIntensity + topRightIntensity;
      
-     float mag = length(vec2(h, v));
+     float mag = abs(length(vec2(h, v)) - invertColor);
      mag = step(threshold, mag);
      
      gl_FragColor = vec4(vec3(mag), 1.0);

--- a/framework/Source/GPUImageXYDerivativeFilter.m
+++ b/framework/Source/GPUImageXYDerivativeFilter.m
@@ -24,7 +24,8 @@ NSString *const kGPUImageGradientFragmentShaderString = SHADER_STRING
  varying vec2 bottomRightTextureCoordinate;
  
  uniform sampler2D inputImageTexture;
- 
+ uniform lowp float invertColor;
+
  void main()
  {
      float topIntensity = texture2D(inputImageTexture, topTextureCoordinate).r;
@@ -61,6 +62,7 @@ NSString *const kGPUImageGradientFragmentShaderString = SHADER_STRING
  varying vec2 bottomRightTextureCoordinate;
  
  uniform sampler2D inputImageTexture;
+ uniform float invertColor;
  
  void main()
  {


### PR DESCRIPTION
Normally the edge detection filters are black with white lines. This
allows having black lines with white filling.
