### PR TITLE
Prevent CGContextDrawImage error when empty images are passed to GPUImagePicture init

### DIFF
--- a/framework/Source/iOS/GPUImagePicture.m
+++ b/framework/Source/iOS/GPUImagePicture.m
@@ -67,6 +67,17 @@
     // TODO: Dispatch this whole thing asynchronously to move image loading off main thread
     CGFloat widthOfImage = CGImageGetWidth(newImageSource);
     CGFloat heightOfImage = CGImageGetHeight(newImageSource);
+
+    // If passed an empty image reference, create a small 2x2 image so we don't trigger a fatal error in the future on CGContextDrawImage below
+    if( !(widthOfImage >= 1) || !(heightOfImage >= 1) ){
+        widthOfImage = heightOfImage = 2.0;
+        UIGraphicsBeginImageContextWithOptions(CGSizeMake(widthOfImage, heightOfImage), NO, 0.0);
+        UIImage *blank = UIGraphicsGetImageFromCurrentImageContext();
+        UIGraphicsEndImageContext();
+        newImageSource = blank.CGImage;
+        blank = nil;
+    }
+    
     pixelSizeOfImage = CGSizeMake(widthOfImage, heightOfImage);
     CGSize pixelSizeToUseForTexture = pixelSizeOfImage;
     


### PR DESCRIPTION
The empty image passed to GPUImagePicture will trigger this error when CGContextDrawImage is called on init::

"<Error>: CGContextDrawImage: invalid context 0x0. This is a serious error. This application, or a library it uses, is using an invalid context  and is thereby contributing to an overall degradation of system stability and reliability. This notice is a courtesy: please fix this problem. It will become a fatal error in an upcoming update."

This should prevent the error altogether.
