### PR TITLE
GPUImageVideoCamera: make class methods to determine which cameras exist

### DIFF
--- a/framework/Source/GPUImageVideoCamera.h
+++ b/framework/Source/GPUImageVideoCamera.h
@@ -50,8 +50,9 @@
  */
 @property (readwrite) NSInteger frameRate;
 
-/// Easy way to tell if front-facing camera is present on device
+/// Easy way to tell which cameras are present on device
 @property (readonly, getter = isFrontFacingCameraPresent) BOOL frontFacingCameraPresent;
+@property (readonly, getter = isBackFacingCameraPresent) BOOL backFacingCameraPresent;
 
 /// This enables the benchmarking mode, which logs out instantaneous and average frame times to the console
 @property(readwrite, nonatomic) BOOL runBenchmark;
@@ -127,5 +128,8 @@
 /** When benchmarking is enabled, this will keep a running average of the time from uploading, processing, and final recording or display
  */
 - (CGFloat)averageFrameDurationDuringCapture;
+
++ (BOOL)isBackFacingCameraPresent;
++ (BOOL)isFrontFacingCameraPresent;
 
 @end

--- a/framework/Source/GPUImageVideoCamera.m
+++ b/framework/Source/GPUImageVideoCamera.m
@@ -419,7 +419,25 @@ NSString *const kGPUImageYUVVideoRangeConversionForLAFragmentShaderString = SHAD
     return [[videoInput device] position];
 }
 
-- (BOOL)isFrontFacingCameraPresent;
++ (BOOL)isBackFacingCameraPresent;
+{
+	NSArray *devices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
+	
+	for (AVCaptureDevice *device in devices)
+	{
+		if ([device position] == AVCaptureDevicePositionBack)
+			return YES;
+	}
+	
+	return NO;
+}
+
+- (BOOL)isBackFacingCameraPresent
+{
+    return [GPUImageVideoCamera isBackFacingCameraPresent];
+}
+
++ (BOOL)isFrontFacingCameraPresent;
 {
 	NSArray *devices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
 	
@@ -430,6 +448,11 @@ NSString *const kGPUImageYUVVideoRangeConversionForLAFragmentShaderString = SHAD
 	}
 	
 	return NO;
+}
+
+- (BOOL)isFrontFacingCameraPresent
+{
+    return [GPUImageVideoCamera isFrontFacingCameraPresent];
 }
 
 - (void)setCaptureSessionPreset:(NSString *)captureSessionPreset;


### PR DESCRIPTION
The new iPod Touch doesn't have a back camera, so it's useful to determine which cameras exist before initting the GPUImageVideoCamera.

I have left instance methods of the same name so that the property getters still work, there are just class method alternatives now too.
