### PR TITLE
Introduced outputTextureOptions for GPUImageOutput.

### DIFF
--- a/framework/Source/GPUImageAverageColor.m
+++ b/framework/Source/GPUImageAverageColor.m
@@ -149,10 +149,10 @@ NSString *const kGPUImageColorAveragingFragmentShaderString = SHADER_STRING
             GLuint textureForStage;
             glGenTextures(1, &textureForStage);
             glBindTexture(GL_TEXTURE_2D, textureForStage);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, self.outputTextureOptions.minFilter);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, self.outputTextureOptions.magFilter);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, self.outputTextureOptions.wrapS);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, self.outputTextureOptions.wrapT);
             [stageTextures addObject:[NSNumber numberWithInt:textureForStage]];
             
 //            NSLog(@"At reduction: %d size in X: %f, size in Y:%f", currentReduction, currentStageSize.width, currentStageSize.height);
@@ -220,7 +220,15 @@ NSString *const kGPUImageColorAveragingFragmentShaderString = SHADER_STRING
 #endif
             
 //            NSLog(@"FBO stage size: %f, %f", currentFramebufferSize.width, currentFramebufferSize.height);
-            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, (int)currentFramebufferSize.width, (int)currentFramebufferSize.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, 0);
+            glTexImage2D(GL_TEXTURE_2D,
+                         0,
+                         self.outputTextureOptions.internalFormat,
+                         (int)currentFramebufferSize.width,
+                         (int)currentFramebufferSize.height,
+                         0,
+                         self.outputTextureOptions.format,
+                         self.outputTextureOptions.type,
+                         0);
             glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, currentTexture, 0);
             GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
             
@@ -339,6 +347,10 @@ NSString *const kGPUImageColorAveragingFragmentShaderString = SHADER_STRING
 
 - (void)extractAverageColorAtFrameTime:(CMTime)frameTime;
 {
+    // we need a normal color texture for averaging the color values
+    NSAssert(self.outputTextureOptions.format == GL_RGBA, @"The output texture format for this filter must be GL_RGBA.");
+    NSAssert(self.outputTextureOptions.type == GL_UNSIGNED_BYTE, @"The type of the output texture of this filter must be GL_UNSIGNED_BYTE.");
+    
 #if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
     CGSize finalStageSize = [[stageSizes lastObject] CGSizeValue];
 #else

--- a/framework/Source/GPUImageBuffer.m
+++ b/framework/Source/GPUImageBuffer.m
@@ -127,14 +127,22 @@
         glActiveTexture(GL_TEXTURE0);
         glGenTextures(1, &newTextureName);
         glBindTexture(GL_TEXTURE_2D, newTextureName);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, self.outputTextureOptions.minFilter);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, self.outputTextureOptions.magFilter);
         // This is necessary for non-power-of-two textures
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, self.outputTextureOptions.wrapS);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, self.outputTextureOptions.wrapT);
         
         CGSize currentFBOSize = [self sizeOfFBO];
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, (int)currentFBOSize.width, (int)currentFBOSize.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, 0);
+        glTexImage2D(GL_TEXTURE_2D,
+                     0,
+                     self.outputTextureOptions.internalFormat,
+                     (int)currentFBOSize.width,
+                     (int)currentFBOSize.height,
+                     0,
+                     self.outputTextureOptions.format,
+                     self.outputTextureOptions.type,
+                     0);
         glBindTexture(GL_TEXTURE_2D, 0);
         
     });

--- a/framework/Source/GPUImageFilter.m
+++ b/framework/Source/GPUImageFilter.m
@@ -186,6 +186,11 @@ void dataProviderUnlockCallback (void *info, const void *data, size_t size)
 
 - (CGImageRef)newCGImageFromCurrentlyProcessedOutputWithOrientation:(UIImageOrientation)imageOrientation
 {
+    
+    // a CGImage can only be created from a 'normal' color texture
+    NSAssert(self.outputTextureOptions.format == GL_RGBA, @"For conversion to a CGImage the output texture format for this filter must be GL_RGBA.");
+    NSAssert(self.outputTextureOptions.type == GL_UNSIGNED_BYTE, @"For conversion to a CGImage the type of the output texture of this filter must be GL_UNSIGNED_BYTE.");
+    
     __block CGImageRef cgImageFromBytes;
 
     runSynchronouslyOnVideoProcessingQueue(^{
@@ -316,11 +321,11 @@ void dataProviderUnlockCallback (void *info, const void *data, size_t size)
                                                                 filterTextureCache, renderTarget,
                                                                 NULL, // texture attributes
                                                                 GL_TEXTURE_2D,
-                                                                GL_RGBA, // opengl format
+                                                                self.outputTextureOptions.internalFormat, // opengl format
                                                                 (int)currentFBOSize.width,
                                                                 (int)currentFBOSize.height,
-                                                                GL_BGRA, // native iOS format
-                                                                GL_UNSIGNED_BYTE,
+                                                                self.outputTextureOptions.format, // native iOS format
+                                                                self.outputTextureOptions.type,
                                                                 0,
                                                                 &renderTexture);
             if (err)
@@ -333,8 +338,8 @@ void dataProviderUnlockCallback (void *info, const void *data, size_t size)
 
             glBindTexture(CVOpenGLESTextureGetTarget(renderTexture), CVOpenGLESTextureGetName(renderTexture));
             outputTexture = CVOpenGLESTextureGetName(renderTexture);
-            glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-            glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+            glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, self.outputTextureOptions.wrapS);
+            glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, self.outputTextureOptions.wrapT);
             
             glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, CVOpenGLESTextureGetName(renderTexture), 0);
             
@@ -353,7 +358,15 @@ void dataProviderUnlockCallback (void *info, const void *data, size_t size)
 //            }
 //            else
 //            {
-                glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, (int)currentFBOSize.width, (int)currentFBOSize.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, 0);
+                glTexImage2D(GL_TEXTURE_2D,
+                             0,
+                             self.outputTextureOptions.internalFormat,
+                             (int)currentFBOSize.width,
+                             (int)currentFBOSize.height,
+                             0,
+                             self.outputTextureOptions.format,
+                             self.outputTextureOptions.type,
+                             0);
 //            }
             glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, outputTexture, 0);
 //            glBindFramebuffer(GL_FRAMEBUFFER, filterFramebuffer);

--- a/framework/Source/GPUImageHarrisCornerDetectionFilter.m
+++ b/framework/Source/GPUImageHarrisCornerDetectionFilter.m
@@ -203,6 +203,9 @@ NSString *const kGPUImageHarrisCornerDetectionFragmentShaderString = SHADER_STRI
 
 - (void)extractCornerLocationsFromImageAtFrameTime:(CMTime)frameTime;
 {
+    // we need a normal color texture for this filter
+    NSAssert(self.outputTextureOptions.format == GL_RGBA, @"The output texture format for this filter must be GL_RGBA.");
+    NSAssert(self.outputTextureOptions.type == GL_UNSIGNED_BYTE, @"The type of the output texture of this filter must be GL_UNSIGNED_BYTE.");
 
     NSUInteger numberOfCorners = 0;
     CGSize imageSize = nonMaximumSuppressionFilter.outputFrameSize;

--- a/framework/Source/GPUImageHistogramFilter.m
+++ b/framework/Source/GPUImageHistogramFilter.m
@@ -263,6 +263,10 @@ NSString *const kGPUImageHistogramAccumulationFragmentShaderString = SHADER_STRI
 
 - (void)renderToTextureWithVertices:(const GLfloat *)vertices textureCoordinates:(const GLfloat *)textureCoordinates sourceTexture:(GLuint)sourceTexture;
 {
+    // we need a normal color texture for this filter
+    NSAssert(self.outputTextureOptions.format == GL_RGBA, @"The output texture format for this filter must be GL_RGBA.");
+    NSAssert(self.outputTextureOptions.type == GL_UNSIGNED_BYTE, @"The type of the output texture of this filter must be GL_UNSIGNED_BYTE.");
+    
     if (self.preventRendering)
     {
         return;

--- a/framework/Source/GPUImageHoughTransformLineDetector.m
+++ b/framework/Source/GPUImageHoughTransformLineDetector.m
@@ -111,6 +111,9 @@
 
 - (void)extractLineParametersFromImageAtFrameTime:(CMTime)frameTime;
 {
+    // we need a normal color texture for this filter
+    NSAssert(self.outputTextureOptions.format == GL_RGBA, @"The output texture format for this filter must be GL_RGBA.");
+    NSAssert(self.outputTextureOptions.type == GL_UNSIGNED_BYTE, @"The type of the output texture of this filter must be GL_UNSIGNED_BYTE.");
     
     NSUInteger numberOfLines = 0;
     CGSize imageSize = nonMaximumSuppressionFilter.outputFrameSize;

--- a/framework/Source/GPUImageJFAVoronoiFilter.m
+++ b/framework/Source/GPUImageJFAVoronoiFilter.m
@@ -370,19 +370,19 @@ NSString *const kGPUImageJFAVoronoiFragmentShaderString = SHADER_STRING
     glActiveTexture(GL_TEXTURE2);
     glGenTextures(1, &outputTexture);
 	glBindTexture(GL_TEXTURE_2D, outputTexture);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, self.outputTextureOptions.minFilter);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, self.outputTextureOptions.magFilter);
 	// This is necessary for non-power-of-two textures
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, self.outputTextureOptions.wrapS);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, self.outputTextureOptions.wrapT);
     glBindTexture(GL_TEXTURE_2D, 0);
     
     glGenTextures(1, &secondFilterOutputTexture);
 	glBindTexture(GL_TEXTURE_2D, secondFilterOutputTexture);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, self.outputTextureOptions.minFilter);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, self.outputTextureOptions.magFilter);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, self.outputTextureOptions.wrapS);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, self.outputTextureOptions.wrapT);
     glBindTexture(GL_TEXTURE_2D, 0);
 }
 
@@ -459,11 +459,11 @@ NSString *const kGPUImageJFAVoronoiFragmentShaderString = SHADER_STRING
                                                             filterTextureCache, renderTarget,
                                                             NULL, // texture attributes
                                                             GL_TEXTURE_2D,
-                                                            GL_RGBA, // opengl format
+                                                            self.outputTextureOptions.internalFormat, // opengl format
                                                             (int)currentFBOSize.width,
                                                             (int)currentFBOSize.height,
-                                                            GL_BGRA, // native iOS format
-                                                            GL_UNSIGNED_BYTE,
+                                                            self.outputTextureOptions.format, // native iOS format
+                                                            self.outputTextureOptions.type,
                                                             0,
                                                             &renderTexture);
         if (err)
@@ -475,8 +475,8 @@ NSString *const kGPUImageJFAVoronoiFragmentShaderString = SHADER_STRING
         CFRelease(empty);
         glBindTexture(CVOpenGLESTextureGetTarget(renderTexture), CVOpenGLESTextureGetName(renderTexture));
         secondFilterOutputTexture = CVOpenGLESTextureGetName(renderTexture);
-        glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+        glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, self.outputTextureOptions.wrapS);
+        glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, self.outputTextureOptions.wrapS);
         
         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, CVOpenGLESTextureGetName(renderTexture), 0);
         
@@ -488,19 +488,27 @@ NSString *const kGPUImageJFAVoronoiFragmentShaderString = SHADER_STRING
         [self initializeOutputTextureIfNeeded];
         
         glBindTexture(GL_TEXTURE_2D, secondFilterOutputTexture);
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, (int)currentFBOSize.width, (int)currentFBOSize.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, 0);
+        glTexImage2D(GL_TEXTURE_2D,
+                     0,
+                     self.outputTextureOptions.internalFormat,
+                     (int)currentFBOSize.width,
+                     (int)currentFBOSize.height,
+                     0,
+                     self.outputTextureOptions.format,
+                     self.outputTextureOptions.type,
+                     0);
         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, secondFilterOutputTexture, 0);
         
         [self notifyTargetsAboutNewOutputTexture];
     }
     
     glBindTexture(GL_TEXTURE_2D, outputTexture);
-    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, self.outputTextureOptions.magFilter);
+    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, self.outputTextureOptions.minFilter);
     
     glBindTexture(GL_TEXTURE_2D, secondFilterOutputTexture);
-    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, self.outputTextureOptions.magFilter);
+    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, self.outputTextureOptions.minFilter);
     
 	GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
     

--- a/framework/Source/GPUImageLuminosity.m
+++ b/framework/Source/GPUImageLuminosity.m
@@ -289,6 +289,10 @@ NSString *const kGPUImageLuminosityFragmentShaderString = SHADER_STRING
 
 - (void)extractLuminosityAtFrameTime:(CMTime)frameTime;
 {
+    // we need a normal color texture for this filter
+    NSAssert(self.outputTextureOptions.format == GL_RGBA, @"The output texture format for this filter must be GL_RGBA.");
+    NSAssert(self.outputTextureOptions.type == GL_UNSIGNED_BYTE, @"The type of the output texture of this filter must be GL_UNSIGNED_BYTE.");
+    
 #if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
     CGSize finalStageSize = [[stageSizes lastObject] CGSizeValue];
 #else

--- a/framework/Source/GPUImageMovie.m
+++ b/framework/Source/GPUImageMovie.m
@@ -302,7 +302,18 @@
         
         [GPUImageContext useImageProcessingContext];
         CVOpenGLESTextureRef texture = NULL;
-        CVReturn err = CVOpenGLESTextureCacheCreateTextureFromImage(kCFAllocatorDefault, coreVideoTextureCache, movieFrame, NULL, GL_TEXTURE_2D, GL_RGBA, bufferWidth, bufferHeight, GL_BGRA, GL_UNSIGNED_BYTE, 0, &texture);
+        CVReturn err = CVOpenGLESTextureCacheCreateTextureFromImage(kCFAllocatorDefault,
+                                                                    coreVideoTextureCache,
+                                                                    movieFrame,
+                                                                    NULL,
+                                                                    GL_TEXTURE_2D,
+                                                                    self.outputTextureOptions.internalFormat,
+                                                                    bufferWidth,
+                                                                    bufferHeight,
+                                                                    self.outputTextureOptions.format,
+                                                                    self.outputTextureOptions.type,
+                                                                    0,
+                                                                    &texture);
         
         if (!texture || err) {
             NSLog(@"Movie CVOpenGLESTextureCacheCreateTextureFromImage failed (error: %d)", err);  
@@ -312,10 +323,10 @@
         outputTexture = CVOpenGLESTextureGetName(texture);
         //        glBindTexture(CVOpenGLESTextureGetTarget(texture), outputTexture);
         glBindTexture(GL_TEXTURE_2D, outputTexture);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, self.outputTextureOptions.minFilter);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, self.outputTextureOptions.magFilter);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, self.outputTextureOptions.wrapS);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, self.outputTextureOptions.wrapT);
         
         for (id<GPUImageInput> currentTarget in targets)
         {
@@ -343,7 +354,15 @@
         
         glBindTexture(GL_TEXTURE_2D, outputTexture);
         // Using BGRA extension to pull in video frame data directly
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, bufferWidth, bufferHeight, 0, GL_BGRA, GL_UNSIGNED_BYTE, CVPixelBufferGetBaseAddress(movieFrame));
+        glTexImage2D(GL_TEXTURE_2D,
+                     0,
+                     self.outputTextureOptions.internalFormat,
+                     bufferWidth,
+                     bufferHeight,
+                     0,
+                     self.outputTextureOptions.format,
+                     self.outputTextureOptions.type,
+                     CVPixelBufferGetBaseAddress(movieFrame));
         
         CGSize currentSize = CGSizeMake(bufferWidth, bufferHeight);
         for (id<GPUImageInput> currentTarget in targets)

--- a/framework/Source/GPUImageOutput.h
+++ b/framework/Source/GPUImageOutput.h
@@ -16,6 +16,16 @@ typedef NS_ENUM(NSInteger, UIImageOrientation) {
 };
 #endif
 
+typedef struct GPUTextureOptions {
+    GLenum minFilter;
+    GLenum magFilter;
+    GLenum wrapS;
+    GLenum wrapT;
+    GLenum internalFormat;
+    GLenum format;
+    GLenum type;
+} GPUTextureOptions;
+
 void runOnMainQueueWithoutDeadlocking(void (^block)(void));
 void runSynchronouslyOnVideoProcessingQueue(void (^block)(void));
 void runAsynchronouslyOnVideoProcessingQueue(void (^block)(void));
@@ -58,6 +68,7 @@ void reportAvailableMemoryForGPUImage(NSString *tag);
 @property(readwrite, nonatomic, unsafe_unretained) id<GPUImageInput> targetToIgnoreForUpdates;
 @property(nonatomic, copy) void(^frameProcessingCompletionBlock)(GPUImageOutput*, CMTime);
 @property(nonatomic) BOOL enabled;
+@property(readwrite, nonatomic) GPUTextureOptions outputTextureOptions;
 
 /// @name Managing targets
 - (void)setInputTextureForTarget:(id<GPUImageInput>)target atIndex:(NSInteger)inputTextureIndex;

--- a/framework/Source/GPUImageOutput.m
+++ b/framework/Source/GPUImageOutput.m
@@ -79,6 +79,7 @@ void reportAvailableMemoryForGPUImage(NSString *tag)
 @synthesize targetToIgnoreForUpdates = _targetToIgnoreForUpdates;
 @synthesize frameProcessingCompletionBlock = _frameProcessingCompletionBlock;
 @synthesize enabled = _enabled;
+@synthesize outputTextureOptions = _outputTextureOptions;
 
 #pragma mark -
 #pragma mark Initialization and teardown
@@ -94,6 +95,15 @@ void reportAvailableMemoryForGPUImage(NSString *tag)
     targetTextureIndices = [[NSMutableArray alloc] init];
     _enabled = YES;
     allTargetsWantMonochromeData = YES;
+    
+    // set default texture options
+    _outputTextureOptions.minFilter = GL_LINEAR;
+    _outputTextureOptions.magFilter = GL_LINEAR;
+    _outputTextureOptions.wrapS = GL_CLAMP_TO_EDGE;
+    _outputTextureOptions.wrapT = GL_CLAMP_TO_EDGE;
+    _outputTextureOptions.internalFormat = GL_RGBA;
+    _outputTextureOptions.format = GL_BGRA;
+    _outputTextureOptions.type = GL_UNSIGNED_BYTE;
 
     return self;
 }
@@ -225,11 +235,11 @@ void reportAvailableMemoryForGPUImage(NSString *tag)
             glActiveTexture(GL_TEXTURE0);
             glGenTextures(1, &outputTexture);
             glBindTexture(GL_TEXTURE_2D, outputTexture);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, self.outputTextureOptions.minFilter);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, self.outputTextureOptions.magFilter);
             // This is necessary for non-power-of-two textures
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, self.outputTextureOptions.wrapS);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, self.outputTextureOptions.wrapT);
             glBindTexture(GL_TEXTURE_2D, 0);
         }
     });

--- a/framework/Source/GPUImageParallelCoordinateLineTransformFilter.m
+++ b/framework/Source/GPUImageParallelCoordinateLineTransformFilter.m
@@ -141,6 +141,10 @@ NSString *const kGPUImageHoughAccumulationFBOReadFragmentShaderString = SHADER_S
 
 - (void)renderToTextureWithVertices:(const GLfloat *)vertices textureCoordinates:(const GLfloat *)textureCoordinates sourceTexture:(GLuint)sourceTexture;
 {
+    // we need a normal color texture for this filter
+    NSAssert(self.outputTextureOptions.format == GL_RGBA, @"The output texture format for this filter must be GL_RGBA.");
+    NSAssert(self.outputTextureOptions.type == GL_UNSIGNED_BYTE, @"The type of the output texture of this filter must be GL_UNSIGNED_BYTE.");
+    
     if (self.preventRendering)
     {
         return;

--- a/framework/Source/GPUImagePoissonBlendFilter.m
+++ b/framework/Source/GPUImagePoissonBlendFilter.m
@@ -222,11 +222,11 @@ NSString *const kGPUImagePoissonBlendFragmentShaderString = SHADER_STRING
                                                                 filterTextureCache, renderTarget,
                                                                 NULL, // texture attributes
                                                                 GL_TEXTURE_2D,
-                                                                GL_RGBA, // opengl format
+                                                                self.outputTextureOptions.internalFormat, // opengl format
                                                                 (int)currentFBOSize.width,
                                                                 (int)currentFBOSize.height,
-                                                                GL_BGRA, // native iOS format
-                                                                GL_UNSIGNED_BYTE,
+                                                                self.outputTextureOptions.format, // native iOS format
+                                                                self.outputTextureOptions.type,
                                                                 0,
                                                                 &renderTexture);
             if (err)
@@ -238,8 +238,8 @@ NSString *const kGPUImagePoissonBlendFragmentShaderString = SHADER_STRING
             CFRelease(empty);
             glBindTexture(CVOpenGLESTextureGetTarget(renderTexture), CVOpenGLESTextureGetName(renderTexture));
             secondFilterOutputTexture = CVOpenGLESTextureGetName(renderTexture);
-            glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-            glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+            glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, self.outputTextureOptions.wrapS);
+            glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, self.outputTextureOptions.wrapT);
             
             glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, CVOpenGLESTextureGetName(renderTexture), 0);
             
@@ -256,7 +256,14 @@ NSString *const kGPUImagePoissonBlendFragmentShaderString = SHADER_STRING
             //            }
             //            else
             //            {
-            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, (int)currentFBOSize.width, (int)currentFBOSize.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, 0);
+            glTexImage2D(GL_TEXTURE_2D,
+                         0,
+                         self.outputTextureOptions.internalFormat,
+                         (int)currentFBOSize.width,
+                         (int)currentFBOSize.height,
+                         0,
+                         self.outputTextureOptions.format,
+                         self.outputTextureOptions.type, 0);
             //            }
             glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, secondFilterOutputTexture, 0);
             

--- a/framework/Source/GPUImageTwoPassFilter.m
+++ b/framework/Source/GPUImageTwoPassFilter.m
@@ -187,11 +187,11 @@
                                                             filterTextureCache, renderTarget,
                                                             NULL, // texture attributes
                                                             GL_TEXTURE_2D,
-                                                            GL_RGBA, // opengl format
+                                                            self.outputTextureOptions.internalFormat, // opengl format
                                                             (int)currentFBOSize.width,
                                                             (int)currentFBOSize.height,
-                                                            GL_BGRA, // native iOS format
-                                                            GL_UNSIGNED_BYTE,
+                                                            self.outputTextureOptions.format, // native iOS format
+                                                            self.outputTextureOptions.type,
                                                             0,
                                                             &renderTexture);
         if (err)
@@ -203,8 +203,8 @@
         CFRelease(empty);
         glBindTexture(CVOpenGLESTextureGetTarget(renderTexture), CVOpenGLESTextureGetName(renderTexture));
         secondFilterOutputTexture = CVOpenGLESTextureGetName(renderTexture);
-        glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+        glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, self.outputTextureOptions.wrapS);
+        glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, self.outputTextureOptions.wrapT);
         
         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, CVOpenGLESTextureGetName(renderTexture), 0);
         
@@ -221,7 +221,15 @@
         //            }
         //            else
         //            {
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, (int)currentFBOSize.width, (int)currentFBOSize.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, 0);
+        glTexImage2D(GL_TEXTURE_2D,
+                     0,
+                     self.outputTextureOptions.internalFormat,
+                     (int)currentFBOSize.width,
+                     (int)currentFBOSize.height,
+                     0,
+                     self.outputTextureOptions.format,
+                     self.outputTextureOptions.type,
+                     0);
         //            }
         
         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, secondFilterOutputTexture, 0);

--- a/framework/Source/GPUImageUIElement.m
+++ b/framework/Source/GPUImageUIElement.m
@@ -90,6 +90,7 @@
     CGColorSpaceRelease(genericRGBColorspace);
     
     glBindTexture(GL_TEXTURE_2D, outputTexture);
+    // no need to use self.outputTextureOptions here, we always need these texture options
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, (int)layerPixelSize.width, (int)layerPixelSize.height, 0, GL_BGRA, GL_UNSIGNED_BYTE, imageData);
     
     free(imageData);

--- a/framework/Source/iOS/GPUImagePicture.m
+++ b/framework/Source/iOS/GPUImagePicture.m
@@ -143,6 +143,7 @@
         {
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
         }
+        // no need to use self.outputTextureOptions here since pictures need this texture formats and type
         glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, (int)pixelSizeToUseForTexture.width, (int)pixelSizeToUseForTexture.height, 0, GL_BGRA, GL_UNSIGNED_BYTE, imageData);
         
         if (self.shouldSmoothlyScaleOutput)


### PR DESCRIPTION
This allows to modify the output texture settings of a filter to, for example, allow float-typed output textures.
Further, one can now optimize the memory usage of filters which do not need four color components, e.g., by using the GL_LUMINANCE format instead of GL_RGBA.

I also tried to introduce the new options in the existing filters. However, I'm not quite sure if I covered them all.
For some places—especially when reading back values from the texture—it did not seam appropriate to change the texture options. I added some assertions to ensure the options are still the defaults.
