### PR TITLE
Tone curve filter: fixes missing last point and incorrect application of RGB curve in conduction with individual channels

### DIFF
--- a/framework/Source/GPUImageToneCurveFilter.m
+++ b/framework/Source/GPUImageToneCurveFilter.m
@@ -510,9 +510,12 @@ NSString *const kGPUImageToneCurveFragmentShaderString = SHADER_STRING
             for (unsigned int currentCurveIndex = 0; currentCurveIndex < 256; currentCurveIndex++)
             {
                 // BGRA for upload to texture
-                toneCurveByteArray[currentCurveIndex * 4] = fmin(fmax(currentCurveIndex + [[_blueCurve objectAtIndex:currentCurveIndex] floatValue] + [[_rgbCompositeCurve objectAtIndex:currentCurveIndex] floatValue], 0), 255);
-                toneCurveByteArray[currentCurveIndex * 4 + 1] = fmin(fmax(currentCurveIndex + [[_greenCurve objectAtIndex:currentCurveIndex] floatValue] + [[_rgbCompositeCurve objectAtIndex:currentCurveIndex] floatValue], 0), 255);
-                toneCurveByteArray[currentCurveIndex * 4 + 2] = fmin(fmax(currentCurveIndex + [[_redCurve objectAtIndex:currentCurveIndex] floatValue] + [[_rgbCompositeCurve objectAtIndex:currentCurveIndex] floatValue], 0), 255);
+                GLubyte b = fmin(fmax(currentCurveIndex + [[_blueCurve objectAtIndex:currentCurveIndex] floatValue], 0), 255);
+                toneCurveByteArray[currentCurveIndex * 4] = fmin(fmax(b + [[_rgbCompositeCurve objectAtIndex:b] floatValue], 0), 255);
+                GLubyte g = fmin(fmax(currentCurveIndex + [[_greenCurve objectAtIndex:currentCurveIndex] floatValue], 0), 255);
+                toneCurveByteArray[currentCurveIndex * 4 + 1] = fmin(fmax(g + [[_rgbCompositeCurve objectAtIndex:g] floatValue], 0), 255);
+                GLubyte r = fmin(fmax(currentCurveIndex + [[_redCurve objectAtIndex:currentCurveIndex] floatValue], 0), 255);
+                toneCurveByteArray[currentCurveIndex * 4 + 2] = fmin(fmax(r + [[_rgbCompositeCurve objectAtIndex:r] floatValue], 0), 255);
                 toneCurveByteArray[currentCurveIndex * 4 + 3] = 255;
             }
             


### PR DESCRIPTION
It looks like I didn't submit a pull request for this back in December when I discovered this issue! Sorry about that.

Firstly, the last point in a curve is missed if the last point has an x value < 1.0. Because the curve gets close but not exactly right this can be a little difficult to see, but I have verified this by examining the array of points produced.

Secondly, the tone curve doesn't correctly apply an RGB curve in conjunction with individual R, G or B curves. The RGB adjustment needs to be made after the individual channels. You can prove this fix with a simple experiment in Photoshop: add a curves adjustment layer with an R curve and an RGB curve. I choose [0,0] [0.5, 0.5] [1.0, 0.1] for both. After this patch the output from GPUImageToneCurveFilter matches the result in Photoshop.
