### PR TITLE
Also build GPUImage as static framework in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -20,3 +20,12 @@ xcrun -sdk iphoneos lipo -info Release-iphone/lib/libGPUImage.a
 mkdir -p Release-iphone/include
 cp ../framework/Source/*.h Release-iphone/include
 cp ../framework/Source/iOS/*.h Release-iphone/include
+
+# Build static framework
+mkdir -p GPUImage.framework/Versions/A
+cp Release-iphone/lib/libGPUImage.a GPUImage.framework/Versions/A/GPUImage
+mkdir -p GPUImage.framework/Versions/A/Headers
+cp Release-iphone/include/*.h GPUImage.framework/Versions/A/Headers
+ln -sfh A GPUImage.framework/Versions/Current
+ln -sfh Versions/Current/GPUImage GPUImage.framework/GPUImage
+ln -sfh Versions/Current/Headers GPUImage.framework/Headers


### PR DESCRIPTION
Adding static framework to Xcode project is slightly easier than adding static libraries, as the headers are automatically handled by Xcode, saved the step for adding headers search path.

p.s. Use `#import <GPUImage/GPUImage.h>` instead of `#import "GPUImage.h"` when we integrate the framework.
