### PR TITLE
Add method in GPUStillImageCamera class that allows for choosing of image orientation position on output

### DIFF
--- a/framework/Source/GPUImageStillCamera.h
+++ b/framework/Source/GPUImageStillCamera.h
@@ -16,6 +16,7 @@ void GPUImageCreateResizedSampleBuffer(CVPixelBufferRef cameraFrame, CGSize fina
 - (void)capturePhotoAsSampleBufferWithCompletionHandler:(void (^)(CMSampleBufferRef imageSampleBuffer, NSError *error))block;
 - (void)capturePhotoAsImageProcessedUpToFilter:(GPUImageOutput<GPUImageInput> *)finalFilterInChain withCompletionHandler:(void (^)(UIImage *processedImage, NSError *error))block;
 - (void)capturePhotoAsJPEGProcessedUpToFilter:(GPUImageOutput<GPUImageInput> *)finalFilterInChain withCompletionHandler:(void (^)(NSData *processedJPEG, NSError *error))block;
+- (void)capturePhotoAsJPEGProcessedUpToFilter:(GPUImageOutput<GPUImageInput> *)finalFilterInChain withImageOrientation:(UIImageOrientation)imageOrientation withCompletionHandler:(void (^)(NSData *processedJPEG, NSError *error))block;
 - (void)capturePhotoAsPNGProcessedUpToFilter:(GPUImageOutput<GPUImageInput> *)finalFilterInChain withCompletionHandler:(void (^)(NSData *processedPNG, NSError *error))block;
 
 @end


### PR DESCRIPTION
Added a method to the GPUStillImageCamera class called 

capturePhotoAsJPEGProcessedUpToFilter: withImageOrientation: withCompletionHandler

that accepts as an argument a direction (UIImageOrientation) of which to use when the method writes the image as a JPEG
