### PR TITLE
GPUImageTwoInputFilter newFrameReadyAtTime can't always pass on frame time from the first input

### DIFF
--- a/framework/Source/GPUImageTwoInputFilter.m
+++ b/framework/Source/GPUImageTwoInputFilter.m
@@ -249,7 +249,8 @@ NSString *const kGPUImageTwoInputTextureVertexShaderString = SHADER_STRING
     // || (hasReceivedFirstFrame && secondFrameCheckDisabled) || (hasReceivedSecondFrame && firstFrameCheckDisabled)
     if ((hasReceivedFirstFrame && hasReceivedSecondFrame) || updatedMovieFrameOppositeStillImage)
     {
-        [super newFrameReadyAtTime:firstFrameTime atIndex:0]; // Bugfix when trying to record: always use time from first input
+        CMTime passOnFrameTime = (!CMTIME_IS_INDEFINITE(firstFrameTime)) ? firstFrameTime : secondFrameTime;
+        [super newFrameReadyAtTime:passOnFrameTime atIndex:0]; // Bugfix when trying to record: always use time from first input (unless indefinite, in which case use the second input)
         hasReceivedFirstFrame = NO;
         hasReceivedSecondFrame = NO;
     }


### PR DESCRIPTION
Sometimes the first input will be a GPUImagePicture with a frameTime of CMTimeIndefinite. I have added a check to see whether the firstFrameTime is indefinite, in which case the secondFrameTime is used.

The behaviour will be the same as before, unless the first input is a GPUImagePicture then the time will be used from the second input. Because the frameTime will always be indefinite it will always use the second frame time and therefore will be stable.
