### PR TITLE
Turn off front-camera workaround on iOS 6 or later

### DIFF
--- a/framework/Source/GPUImageStillCamera.m
+++ b/framework/Source/GPUImageStillCamera.m
@@ -51,7 +51,9 @@ void GPUImageCreateResizedSampleBuffer(CVPixelBufferRef cameraFrame, CGSize fina
 
 @end
 
-@implementation GPUImageStillCamera
+@implementation GPUImageStillCamera {
+    BOOL requiresFrontCameraTextureCacheCorruptionWorkaround;
+}
 
 @synthesize currentCaptureMetadata = _currentCaptureMetadata;
 @synthesize jpegCompressionQuality = _jpegCompressionQuality;
@@ -65,6 +67,9 @@ void GPUImageCreateResizedSampleBuffer(CVPixelBufferRef cameraFrame, CGSize fina
     {
 		return nil;
     }
+    
+    /* Detect iOS version < 6 which require a texture cache corruption workaround */
+    requiresFrontCameraTextureCacheCorruptionWorkaround = [[[UIDevice currentDevice] systemVersion] compare:@"6.0" options:NSNumericSearch] == NSOrderedAscending;
     
     [self.captureSession beginConfiguration];
     
@@ -263,7 +268,7 @@ void GPUImageCreateResizedSampleBuffer(CVPixelBufferRef cameraFrame, CGSize fina
         {
             // This is a workaround for the corrupt images that are sometimes returned when taking a photo with the front camera and using the iOS 5.0 texture caches
             AVCaptureDevicePosition currentCameraPosition = [[videoInput device] position];
-            if ( (currentCameraPosition != AVCaptureDevicePositionFront) || (![GPUImageContext supportsFastTextureUpload]))
+            if ( (currentCameraPosition != AVCaptureDevicePositionFront) || (![GPUImageContext supportsFastTextureUpload]) || !requiresFrontCameraTextureCacheCorruptionWorkaround)
             {
                 dispatch_semaphore_signal(frameRenderingSemaphore);
                 [self captureOutput:photoOutput didOutputSampleBuffer:imageSampleBuffer fromConnection:[[photoOutput connections] objectAtIndex:0]];


### PR DESCRIPTION
As discussed in #462, there are various problems with the workaround for corrupt images on iOS 5. Given that iOS 5 is quite legacy now, I think it's a reasonable solution to turn off that workaround if GPUImage is running on iOS 6 or later.

This could of course be adjusted if the precise version of the OS required for the workaround is not 5.X.
