### PR TITLE
fixed gpuimage benchmark suite for live video streams

### DIFF
--- a/examples/iOS/BenchmarkSuite/BenchmarkSuite/VideoFilteringDisplayController.m
+++ b/examples/iOS/BenchmarkSuite/BenchmarkSuite/VideoFilteringDisplayController.m
@@ -260,8 +260,10 @@
         
         CIImage *outputImage = [sepiaCoreImageFilter outputImage];
 
-        //[coreImageContext drawImage:outputImage atPoint:CGPointMake(0.0, 0.0) fromRect:[inputImage extent]];
-        [coreImageContext drawImage:outputImage inRect:CGRectMake(0, 0, 0, 0) fromRect:[inputImage extent]];
+        CGFloat scale = UIScreen.mainScreen.scale;
+        CGRect s = CGRectMake(0, 0, [[UIScreen mainScreen] bounds].size.width * scale, [[UIScreen mainScreen] bounds].size.height * scale);
+        [coreImageContext drawImage:outputImage inRect:s fromRect:[inputImage extent]];
+        
         [self.openGLESContext presentRenderbuffer:GL_RENDERBUFFER];
         elapsedTime = CFAbsoluteTimeGetCurrent() - startTime;
         


### PR DESCRIPTION
I was getting a "thread exc bad access" error when running the video benchmark tool.  When I upgraded to the new drawImage API, the problem was fixed.
