### PR TITLE
GPUImageLanczosResamplingFilter weird when using with combination of GPUImageCropFilter

### DIFF
--- a/framework/Source/GPUImageLanczosResamplingFilter.m
+++ b/framework/Source/GPUImageLanczosResamplingFilter.m
@@ -168,9 +168,9 @@ NSString *const kGPUImageLanczosFragmentShaderString = SHADER_STRING
     if (GPUImageRotationSwapsWidthAndHeight(inputRotation))
     {
         currentFBOSize.height = self.originalImageSize.height;
-    }
-    else
-    {
+//    }
+//    else
+//    {
         currentFBOSize.width = self.originalImageSize.width;
     }
 


### PR DESCRIPTION
It's related to https://github.com/BradLarson/GPUImage/issues/1134.
