### PR TITLE
Fixes issue when building documentation with spaces in the project directory path.

### DIFF
--- a/framework/GPUImage.xcodeproj/project.pbxproj
+++ b/framework/GPUImage.xcodeproj/project.pbxproj
@@ -1434,7 +1434,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# docsetutil was moved in Xcode 4.3\n# if you're using Xcode 4.2 or earlier, remove --docsetutil-path\n${APPLEDOC_PATH} \\\n--project-name \"GPUImage\" \\\n--project-company \"Sunset Lake Software\" \\\n--company-id \"com.sunsetlakesoftware\" \\\n--output \"${SOURCE_ROOT}/../documentation\" \\\n--keep-undocumented-objects \\\n--keep-undocumented-members \\\n--create-html \\\n--install-docset \\\n--keep-intermediate-files \\\n--no-repeat-first-par \\\n--exit-threshold 9999 \\\n--clean-output \\\n--ignore .m \\\n--logformat xcode \\\n${SOURCE_ROOT}";
+			shellScript = "# docsetutil was moved in Xcode 4.3\n# if you're using Xcode 4.2 or earlier, remove --docsetutil-path\n\"${APPLEDOC_PATH}\" \\\n--project-name \"GPUImage\" \\\n--project-company \"Sunset Lake Software\" \\\n--company-id \"com.sunsetlakesoftware\" \\\n--output \"${SOURCE_ROOT}/../documentation\" \\\n--keep-undocumented-objects \\\n--keep-undocumented-members \\\n--create-html \\\n--install-docset \\\n--keep-intermediate-files \\\n--no-repeat-first-par \\\n--exit-threshold 9999 \\\n--clean-output \\\n--ignore .m \\\n--logformat xcode \\\n\"${SOURCE_ROOT}\"";
 		};
 		BCF1A34214DDB1EC00852800 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
If you cloned GPUImage to a directory with spaces, then the docu build script won't work without quotes around the ${SOURCE_ROOT} path. This commit adds those quotes.

The error you get when you do have quotes is:

```
ERROR: AppledocException: Path or file '/Users/lm/Dropbox/Projects/Open' doesn't exist!
appledoc version: 2.1 (build 840)
```

In this case I've cloned the project into "/Users/lm/Dropbox/Projects/Open Source/GPUImage"
