### PR TITLE
GPUImageMovieWriter: synchronise finishRecording with the movieWritingQueue

### DIFF
--- a/framework/Source/iOS/GPUImageMovieWriter.m
+++ b/framework/Source/iOS/GPUImageMovieWriter.m
@@ -278,26 +278,30 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
 
 - (void)finishRecording;
 {
-    [self finishRecordingWithCompletionHandler:nil];
+    [self finishRecordingWithCompletionHandler:NULL];
 }
 
 - (void)finishRecordingWithCompletionHandler:(void (^)(void))handler;
 {
     runSynchronouslyOnVideoProcessingQueue(^{
-        if (assetWriter.status == AVAssetWriterStatusCompleted || assetWriter.status == AVAssetWriterStatusCancelled
-            || assetWriter.status == AVAssetWriterStatusUnknown)
-        {
-            return;
-        }
-
-        isRecording = NO;
+        
         dispatch_sync(movieWritingQueue, ^{
+            isRecording = NO;
+            
+            if (assetWriter.status == AVAssetWriterStatusCompleted || assetWriter.status == AVAssetWriterStatusCancelled || assetWriter.status == AVAssetWriterStatusUnknown)
+            {
+                if (handler)
+                    runAsynchronouslyOnVideoProcessingQueue(handler);
+                return;
+            }
+            
             [assetWriterVideoInput markAsFinished];
             [assetWriterAudioInput markAsFinished];
 #if (!defined(__IPHONE_6_0) || (__IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_6_0))
             // Not iOS 6 SDK
             [assetWriter finishWriting];
-            if (handler) handler();
+            if (handler)
+                runAsynchronouslyOnVideoProcessingQueue(handler);
 #else
             // iOS 6 SDK
             if ([assetWriter respondsToSelector:@selector(finishWritingWithCompletionHandler:)]) {
@@ -310,7 +314,8 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 [assetWriter finishWriting];
 #pragma clang diagnostic pop
-                if (handler) handler();
+                if (handler)
+                    runAsynchronouslyOnVideoProcessingQueue(handler);
             }
 #endif
         });


### PR DESCRIPTION
As the AVAssetWriter gets started on the movieWritingQueue, so we need to check its state on that queue.

Also need to set isRecording = NO before checking AVAssetWriter state, otherwise in a race condition where frames haven't started arriving and the AVAssetWriter hasn't started writing, we wouldn't stop recording.

Also ensure that the handler is called async, otherwise it is called on the movieWritingQueue, which is dispatch_sync from the video processing queue, so if the user-code in the handler calls anything that dispatch_syncs to the video processing queue: deadlock.
