### PR TITLE
GPUImageMovie asset and error reporting improvements

### DIFF
--- a/framework/Source/GPUImageMovie.h
+++ b/framework/Source/GPUImageMovie.h
@@ -49,6 +49,7 @@
 - (BOOL)readNextVideoFrameFromOutput:(AVAssetReaderOutput *)readerVideoTrackOutput;
 - (BOOL)readNextAudioSampleFromOutput:(AVAssetReaderOutput *)readerAudioTrackOutput;
 - (void)startProcessing;
+- (void)startProcessingWithCompletion:(void(^)(BOOL success, NSError *error))completion;
 - (void)endProcessing;
 - (void)cancelProcessing;
 - (void)processMovieFrame:(CMSampleBufferRef)movieSampleBuffer; 


### PR DESCRIPTION
Load AVAsset tracks asynchronously even if GPUImageMovie is instantiated with an AVAsset instead of an NSURL.

Enable error reporting from startProcessing by changing it to - (void)startProcessingWithCompletion:(void(^)(BOOL success, NSError *error))completion. Still retains backwards compatibility.

processPlayerItem now starts reading the player item asynchronously. We already expect async in the NSURL case so I hope this is okay.

Also corrected a little typo between AVAssetWriterStatusCompleted and AVAssetReaderStatusCompleted.
