### PR TITLE
Fix build errors

### DIFF
--- a/framework/Source/Mac/GPUImageContext.h
+++ b/framework/Source/Mac/GPUImageContext.h
@@ -7,7 +7,7 @@
 
 #define GPUImageRotationSwapsWidthAndHeight(rotation) (((rotation) == kGPUImageRotateLeft) || ((rotation) == kGPUImageRotateRight) || ((rotation) == kGPUImageRotateRightFlipVertical) )
 
-typedef enum { kGPUImageNoRotation, kGPUImageRotateLeft, kGPUImageRotateRight, kGPUImageFlipVertical, kGPUImageFlipHorizonal, kGPUImageRotateRightFlipVertical, kGPUImageRotate180 } GPUImageRotationMode;
+typedef enum { kGPUImageNoRotation, kGPUImageRotateLeft, kGPUImageRotateRight, kGPUImageFlipVertical, kGPUImageFlipHorizonal, kGPUImageRotateRightFlipVertical, kGPUImageRotateRightFlipHorizontal, kGPUImageRotate180 } GPUImageRotationMode;
 
 @interface GPUImageContext : NSObject
 


### PR DESCRIPTION
When I first cloned GPUImage and attempted to build the "FilterShowcase" example, I received several build errors related to a missing `kGPUImageRotateRightFlipHorizontal` type. I added this to the `GPUImageRotationMode` enum in GPUImageContext.h and then was able to build.

Very new to this project, so apologies if I'm missing something here ... this is just what I had to do to get it to build out of the box.
