### PR TITLE
GPUImageMovieWriter now obeys its inputRotation.

### DIFF
--- a/framework/Source/iOS/GPUImageMovieWriter.m
+++ b/framework/Source/iOS/GPUImageMovieWriter.m
@@ -615,12 +615,7 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
         1.0f,  1.0f,
     };
     
-    static const GLfloat textureCoordinates[] = {
-        0.0f, 0.0f,
-        1.0f, 0.0f,
-        0.0f, 1.0f,
-        1.0f, 1.0f,
-    };
+    const GLfloat *textureCoordinates = [GPUImageFilter textureCoordinatesForRotation:inputRotation];
     
 	glActiveTexture(GL_TEXTURE4);
 	glBindTexture(GL_TEXTURE_2D, inputTextureForMovieRendering);


### PR DESCRIPTION
This appears to simply correct the issue of the movie being written with the wrong orientation.

We no longer need to use a dummy filter to correct the orientation as in issue #126.

I've tested this and it works nicely for landscape left and right orientations. I haven't tested for portrait. Can the solution be this simple?
