### PR TITLE
Fixed #if line for iOS7. Previous version occurs memory leaking on iOS7,...

### DIFF
--- a/framework/Source/iOS/GPUImagePicture.m
+++ b/framework/Source/iOS/GPUImagePicture.m
@@ -170,7 +170,7 @@
 }
 
 // ARC forbids explicit message send of 'release'; since iOS 6 even for dispatch_release() calls: stripping it out in that case is required.
-#if ( (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_6_0) || (!defined(__IPHONE_6_0)) )
+#if ( (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_7_0) || (!defined(__IPHONE_7_0)) )
 - (void)dealloc;
 {
     if (imageUpdateSemaphore != NULL)


### PR DESCRIPTION
... because there wasn't called dispatch_release(imageUpdateSemaphore) and libdispatch.dylib's malloc wasn't released.
![screenshot 2013-10-06 18 21 06](https://f.cloud.github.com/assets/988216/1276497/19c785b2-2e6f-11e3-9dc1-3a770b524120.png)
![screenshot 2013-10-06 18 21 11](https://f.cloud.github.com/assets/988216/1276498/1fb801fe-2e6f-11e3-9712-9fdd45b0446e.png)
