### PR TITLE
Fix Xcode 4 compatibility

### DIFF
--- a/framework/Source/GPUImageVideoCamera.m
+++ b/framework/Source/GPUImageVideoCamera.m
@@ -532,8 +532,10 @@ NSString *const kGPUImageYUVVideoRangeConversionForLAFragmentShaderString = SHAD
             NSError *error;
             [_inputCamera lockForConfiguration:&error];
             if (error == nil) {
+#if defined(__IPHONE_7_0)
                 [_inputCamera setActiveVideoMinFrameDuration:CMTimeMake(1, _frameRate)];
                 [_inputCamera setActiveVideoMaxFrameDuration:CMTimeMake(1, _frameRate)];
+#endif
             }
             [_inputCamera unlockForConfiguration];
             
@@ -561,8 +563,10 @@ NSString *const kGPUImageYUVVideoRangeConversionForLAFragmentShaderString = SHAD
             NSError *error;
             [_inputCamera lockForConfiguration:&error];
             if (error == nil) {
+#if defined(__IPHONE_7_0)
                 [_inputCamera setActiveVideoMinFrameDuration:kCMTimeInvalid];
                 [_inputCamera setActiveVideoMaxFrameDuration:kCMTimeInvalid];
+#endif
             }
             [_inputCamera unlockForConfiguration];
             


### PR DESCRIPTION
Some iOS SDK 7-only prevent successful building on Xcode 4.x (Base SDK iOS 6).
