### PR TITLE
GPUImagePicture: don't redraw using CoreGraphics unless you have to

### DIFF
--- a/framework/Source/iOS/GPUImagePicture.m
+++ b/framework/Source/iOS/GPUImagePicture.m
@@ -98,12 +98,42 @@
     
     GLubyte *imageData = NULL;
     CFDataRef dataFromImageDataProvider;
+    GLenum format = GL_BGRA;
+    
+    if (!shouldRedrawUsingCoreGraphics) {
+        /* Check that the bitmap pixel format is compatible with GL */
+        CGBitmapInfo bitmapInfo = CGImageGetBitmapInfo(newImageSource);
+        if ((bitmapInfo & kCGBitmapFloatComponents) != 0) {
+            /* We don't support float components for use directly in GL */
+            shouldRedrawUsingCoreGraphics = YES;
+        } else {
+            CGBitmapInfo byteOrderInfo = bitmapInfo & kCGBitmapByteOrderMask;
+            if (byteOrderInfo == kCGBitmapByteOrder32Little) {
+                /* Little endian, for alpha-first we can use this bitmap directly in GL */
+                CGImageAlphaInfo alphaInfo = bitmapInfo & kCGBitmapAlphaInfoMask;
+                if (alphaInfo != kCGImageAlphaPremultipliedFirst && alphaInfo != kCGImageAlphaFirst &&
+                    alphaInfo != kCGImageAlphaNoneSkipFirst) {
+                    shouldRedrawUsingCoreGraphics = YES;
+                }
+            } else if (byteOrderInfo == kCGBitmapByteOrderDefault || byteOrderInfo == kCGBitmapByteOrder32Big) {
+                /* Big endian, for alpha-last we can use this bitmap directly in GL */
+                CGImageAlphaInfo alphaInfo = bitmapInfo & kCGBitmapAlphaInfoMask;
+                if (alphaInfo != kCGImageAlphaPremultipliedLast && alphaInfo != kCGImageAlphaLast &&
+                    alphaInfo != kCGImageAlphaNoneSkipLast) {
+                    shouldRedrawUsingCoreGraphics = YES;
+                } else {
+                    /* Can access directly using GL_RGBA pixel format */
+                    format = GL_RGBA;
+                }
+            }
+        }
+    }
     
     //    CFAbsoluteTime elapsedTime, startTime = CFAbsoluteTimeGetCurrent();
     
     if (shouldRedrawUsingCoreGraphics)
     {
-        // For resized image, redraw
+        // For resized or incompatible image: redraw
         imageData = (GLubyte *) calloc(1, (int)pixelSizeToUseForTexture.width * (int)pixelSizeToUseForTexture.height * 4);
         
         CGColorSpaceRef genericRGBColorspace = CGColorSpaceCreateDeviceRGB();
@@ -148,7 +178,7 @@
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
         }
         // no need to use self.outputTextureOptions here since pictures need this texture formats and type
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, (int)pixelSizeToUseForTexture.width, (int)pixelSizeToUseForTexture.height, 0, GL_BGRA, GL_UNSIGNED_BYTE, imageData);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, (int)pixelSizeToUseForTexture.width, (int)pixelSizeToUseForTexture.height, 0, format, GL_UNSIGNED_BYTE, imageData);
         
         if (self.shouldSmoothlyScaleOutput)
         {


### PR DESCRIPTION
There was support for this but it appeared to have been disabled. I've tested this in my project and it seems to still work as expected, and significantly reduces memory usage by not needing to redraw these graphics. I think was just a typo.
