### PR TITLE
Add Podspec file to repository

### DIFF
--- a/GPUImage.podspec
+++ b/GPUImage.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name     = 'GPUImage'
+  s.version  = '0.1.1'
+  s.license  = 'BSD'
+  s.platform = :ios, '5.0'
+  s.summary  = 'An open source iOS framework for GPU-based image and video processing.'
+  s.homepage = 'https://github.com/BradLarson/GPUImage'
+  s.author   = { 'Brad Larson' => 'contact@sunsetlakesoftware.com' }
+  s.source   = { :git => 'https://github.com/BradLarson/GPUImage.git', :tag => "#{s.version}" }
+  s.source_files = 'framework/Source/**/*.{h,m}'
+  s.resources = 'framework/Resources/*.png'
+  s.osx.exclude_files = 'framework/Source/iOS/**/*.{h,m}'
+  s.ios.exclude_files = 'framework/Source/Mac/**/*.{h,m}'
+  s.frameworks   = ['OpenGLES', 'CoreVideo', 'CoreMedia', 'QuartzCore', 'AVFoundation']
+  s.requires_arc = true
+end


### PR DESCRIPTION
This will allow people using GPUImage from Cocoapods (#749, #802, #1148, #1252, [etc.](https://github.com/BradLarson/GPUImage/search?q=cocoapods&type=Issues)) to:
- Force the latest version of the library at any time with `pod 'GPUImage', :head`.
- Specify a given commit and/or fork to use with `pod 'GPUImage', :git => 'https://github.com/...', :commit => '...`.

All without requiring to set version tags (although they would still be very much appreciated!).
