### PR TITLE
Fix infinite loops related to endProcess on GPUImageFilter

### DIFF
--- a/framework/Source/GPUImageFilter.h
+++ b/framework/Source/GPUImageFilter.h
@@ -57,6 +57,7 @@ typedef struct GPUMatrix3x3 GPUMatrix3x3;
     GLfloat backgroundColorRed, backgroundColorGreen, backgroundColorBlue, backgroundColorAlpha;
     
     BOOL preparedToCaptureImage;
+    BOOL isEndProcessing;
 
     // Texture caches are an iOS-specific capability
 #if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE

--- a/framework/Source/GPUImageFilter.m
+++ b/framework/Source/GPUImageFilter.m
@@ -1002,9 +1002,14 @@ void dataProviderUnlockCallback (void *info, const void *data, size_t size)
 
 - (void)endProcessing 
 {
-    for (id<GPUImageInput> currentTarget in targets)
+    if (!isEndProcessing)
     {
-        [currentTarget endProcessing];
+        isEndProcessing = YES;
+        
+        for (id<GPUImageInput> currentTarget in targets)
+        {
+            [currentTarget endProcessing];
+        }
     }
 }
 

--- a/framework/Source/GPUImageFilterGroup.h
+++ b/framework/Source/GPUImageFilterGroup.h
@@ -4,6 +4,7 @@
 @interface GPUImageFilterGroup : GPUImageOutput <GPUImageInput, GPUImageTextureDelegate>
 {
     NSMutableArray *filters;
+    BOOL isEndProcessing;
 }
 
 @property(readwrite, nonatomic, strong) GPUImageOutput<GPUImageInput> *terminalFilter;

--- a/framework/Source/GPUImageFilterGroup.m
+++ b/framework/Source/GPUImageFilterGroup.m
@@ -182,9 +182,14 @@
 
 - (void)endProcessing;
 {
-    for (GPUImageOutput<GPUImageInput> *currentFilter in _initialFilters)
+    if (!isEndProcessing)
     {
-        [currentFilter endProcessing];
+        isEndProcessing = YES;
+        
+        for (id<GPUImageInput> currentTarget in targets)
+        {
+            [currentTarget endProcessing];
+        }
     }
 }
 


### PR DESCRIPTION
When removeTarget is called on a GPUImageFilter that contains a loop in the filter outputs (such as GPUImageLowPassFilter), an infinite loop is created while tearing down the filters. This loop comes from recursive calls to endProcess.

We can avoid this by adding a status flag in the GPUImageFilter and GPUImageFilterGroup to check if the filter has already started the endProcess method and do no work if it has already started.

This resolves issue: #793
