### PR TITLE
Fix exc-bad-access if GPUImageRawDataOutput is initialized during render

### DIFF
--- a/framework/Source/GPUImageRawDataOutput.m
+++ b/framework/Source/GPUImageRawDataOutput.m
@@ -85,12 +85,6 @@
     dataTextureCoordinateAttribute = [dataProgram attributeIndex:@"inputTextureCoordinate"];
     dataInputTextureUniform = [dataProgram uniformIndex:@"inputImageTexture"];
     
-    // REFACTOR: Wrap this in a block for the image processing queue
-    [GPUImageContext setActiveShaderProgram:dataProgram];
-
-	glEnableVertexAttribArray(dataPositionAttribute);
-	glEnableVertexAttribArray(dataTextureCoordinateAttribute);
-
     return self;
 }
 
@@ -304,6 +298,9 @@
     
     glVertexAttribPointer(dataPositionAttribute, 2, GL_FLOAT, 0, 0, squareVertices);
 	glVertexAttribPointer(dataTextureCoordinateAttribute, 2, GL_FLOAT, 0, 0, textureCoordinates);
+    
+    glEnableVertexAttribArray(dataPositionAttribute);
+	glEnableVertexAttribArray(dataTextureCoordinateAttribute);
     
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 }


### PR DESCRIPTION
If GPUImageRawDataOutput is initialized while the image pipeline is busy rendering other data, an exc-bad-access will occur.

Reason:
GPUImageRawDataOutput can set itself as the active shader program on a queue other than the image processing queue. I noticed your "REFACTOR" note regarding moving this to a block on the image processing queue.

Solution:
Don't set GPUImageRawDataOutput as the active shader program during initialization. And wait to enable the vertex attribute arrays until we actually start rendering data. 

I have a unit test that can reproduce this crash very consistently. I can include that unit test as part of this pull request.

GPUImageMovieWriter likely has the same problem. I see that you have a note about refactoring that code as well. See framework/Source/iOS/GPUImageMovieWriter.m and framework/Source/Mac/GPUImageMovieWriter.m
