### PR TITLE
Screen blend filter expected input as premultiplied alpha.

### DIFF
--- a/framework/Source/GPUImageScreenBlendFilter.m
+++ b/framework/Source/GPUImageScreenBlendFilter.m
@@ -13,8 +13,9 @@ NSString *const kGPUImageScreenBlendFragmentShaderString = SHADER_STRING
  {
      mediump vec4 textureColor = texture2D(inputImageTexture, textureCoordinate);
      mediump vec4 textureColor2 = texture2D(inputImageTexture2, textureCoordinate2);
-     mediump vec4 whiteColor = vec4(1.0);
-     gl_FragColor = whiteColor - ((whiteColor - textureColor2) * (whiteColor - textureColor));
+     mediump vec4 multipliedTextureColor = vec4(textureColor.rgb * textureColor.a, textureColor.a);
+     mediump vec4 multipliedTextureColor2 = vec4(textureColor2.rgb * textureColor2.a, textureColor2.a);
+     gl_FragColor = multipliedTextureColor2 + multipliedTextureColor - (multipliedTextureColor2 * multipliedTextureColor);
  }
 );
 #else
@@ -30,8 +31,9 @@ NSString *const kGPUImageScreenBlendFragmentShaderString = SHADER_STRING
  {
      vec4 textureColor = texture2D(inputImageTexture, textureCoordinate);
      vec4 textureColor2 = texture2D(inputImageTexture2, textureCoordinate2);
-     vec4 whiteColor = vec4(1.0);
-     gl_FragColor = whiteColor - ((whiteColor - textureColor2) * (whiteColor - textureColor));
+     vec4 multipliedTextureColor = vec4(textureColor.rgb * textureColor.a, textureColor.a);
+     vec4 multipliedTextureColor2 = vec4(textureColor2.rgb * textureColor2.a, textureColor2.a);
+     gl_FragColor = multipliedTextureColor2 + multipliedTextureColor - (multipliedTextureColor2 * multipliedTextureColor);
  }
 );
 #endif


### PR DESCRIPTION
I have modified the shader to expect the input as non-premultiplied alpha.

I believe the expected input is unpremultiplied alpha? I'm a bit confused to be honest! I've been working on a filter to unpremultiply alpha and I intend to work that into the GPUImagePicture class so it can fix images on the way in.

Am I right that the shaders should expect unpremultiplied?

Also I changed the screen formula to the slightly simpler version:
B(cb,cs) = 1 – [(1–cb)×(1–cs)] = cb + cs – (cb × cs)

I'm not sure whether this has an efficiency implication.
