### PR TITLE
Enforce premultiplied alpha in GPUImagePicture

### DIFF
--- a/framework/Source/iOS/GPUImagePicture.m
+++ b/framework/Source/iOS/GPUImagePicture.m
@@ -120,15 +120,13 @@
                 if (byteOrderInfo == kCGBitmapByteOrder32Little) {
                     /* Little endian, for alpha-first we can use this bitmap directly in GL */
                     CGImageAlphaInfo alphaInfo = bitmapInfo & kCGBitmapAlphaInfoMask;
-                    if (alphaInfo != kCGImageAlphaPremultipliedFirst && alphaInfo != kCGImageAlphaFirst &&
-                        alphaInfo != kCGImageAlphaNoneSkipFirst) {
+                    if (alphaInfo != kCGImageAlphaPremultipliedFirst && alphaInfo != kCGImageAlphaNoneSkipFirst) {
                         shouldRedrawUsingCoreGraphics = YES;
                     }
                 } else if (byteOrderInfo == kCGBitmapByteOrderDefault || byteOrderInfo == kCGBitmapByteOrder32Big) {
                     /* Big endian, for alpha-last we can use this bitmap directly in GL */
                     CGImageAlphaInfo alphaInfo = bitmapInfo & kCGBitmapAlphaInfoMask;
-                    if (alphaInfo != kCGImageAlphaPremultipliedLast && alphaInfo != kCGImageAlphaLast &&
-                        alphaInfo != kCGImageAlphaNoneSkipLast) {
+                    if (alphaInfo != kCGImageAlphaPremultipliedLast && alphaInfo != kCGImageAlphaNoneSkipLast) {
                         shouldRedrawUsingCoreGraphics = YES;
                     } else {
                         /* Can access directly using GL_RGBA pixel format */


### PR DESCRIPTION
In keeping with what I believe is the correct understanding, that GPUImage expects images to be in premultiplied alpha, I have modified GPUImagePicture so that if the input is not premultiplied (or no alpha) that it redraws it. This is further to the image data compatibility pull request that was accepted earlier - we no longer allow unpremultiplied alpha to go through, we redraw.
