### PR TITLE
Fixed issue with not calling -dealloc(under ARC) after playing PlayerItem.

### DIFF
--- a/framework/Source/GPUImageMovie.m
+++ b/framework/Source/GPUImageMovie.m
@@ -146,10 +146,6 @@
 
 - (void)dealloc
 {
-    runSynchronouslyOnVideoProcessingQueue(^{
-        [displayLink removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
-        displayLink = nil;
-    });
     if ([GPUImageContext supportsFastTextureUpload])
     {
         CFRelease(coreVideoTextureCache);
@@ -637,6 +633,11 @@
         [self.delegate didCompletePlayingMovie];
     }
     self.delegate = nil;
+    
+    runSynchronouslyOnVideoProcessingQueue(^{
+        [displayLink removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+        displayLink = nil;
+    });
 }
 
 - (void)cancelProcessing


### PR DESCRIPTION
When GPUImageMovie plays AVPlayerItem, it creates _displayLink, which in its turn holding GPUImageMovie and block calling -dealloc. So removing of _displayLink has be moved from -dealloc to -endProcessing.
