### PR TITLE
premultiply rgb with alpha value so blending works correctly.

### DIFF
--- a/framework/Source/GPUImageChromaKeyFilter.m
+++ b/framework/Source/GPUImageChromaKeyFilter.m
@@ -29,7 +29,7 @@ NSString *const kGPUImageChromaKeyFragmentShaderString = SHADER_STRING
      
      //     float blendValue = 1.0 - smoothstep(thresholdSensitivity - smoothing, thresholdSensitivity , abs(Cr - maskCr) + abs(Cb - maskCb));
      float blendValue = smoothstep(thresholdSensitivity, thresholdSensitivity + smoothing, distance(vec2(Cr, Cb), vec2(maskCr, maskCb)));
-     gl_FragColor = vec4(textureColor.rgb, textureColor.a * blendValue);
+     gl_FragColor = textureColor.rgba * blendValue;
  }
 );
 #else
@@ -57,7 +57,7 @@ NSString *const kGPUImageChromaKeyFragmentShaderString = SHADER_STRING
      
      //     float blendValue = 1.0 - smoothstep(thresholdSensitivity - smoothing, thresholdSensitivity , abs(Cr - maskCr) + abs(Cb - maskCb));
      float blendValue = smoothstep(thresholdSensitivity, thresholdSensitivity + smoothing, distance(vec2(Cr, Cb), vec2(maskCr, maskCb)));
-     gl_FragColor = vec4(textureColor.rgb, textureColor.a * blendValue);
+     gl_FragColor = textureColor.rgba * blendValue;
  }
  );
 #endif


### PR DESCRIPTION
Signed-off-by: Moritz Möller mmoeller@mxs.de
