### PR TITLE
Remove KVO on frame for GPUImageView, improves performance and fixes iOS 7 support

### DIFF
--- a/framework/Source/iOS/GPUImageView.m
+++ b/framework/Source/iOS/GPUImageView.m
@@ -16,11 +16,15 @@
     GLProgram *displayProgram;
     GLint displayPositionAttribute, displayTextureCoordinateAttribute;
     GLint displayInputTextureUniform;
-    
+
     CGSize inputImageSize;
     GLfloat imageVertices[8];
     GLfloat backgroundColorRed, backgroundColorGreen, backgroundColorBlue, backgroundColorAlpha;
+
+    CGSize boundsSizeAtFrameBufferEpoch;
 }
+
+@property (assign, nonatomic) NSUInteger aspectRatio;
 
 // Initialization and teardown
 - (void)commonInit;
@@ -36,6 +40,7 @@
 
 @implementation GPUImageView
 
+@synthesize aspectRatio;
 @synthesize sizeInPixels = _sizeInPixels;
 @synthesize fillMode = _fillMode;
 @synthesize enabled;
@@ -123,14 +128,12 @@
         _fillMode = kGPUImageFillModePreserveAspectRatio;
         [self createDisplayFramebuffer];
     });
-        
-    [self addObserver:self forKeyPath:@"frame" options:0 context:NULL];
 }
 
-- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
-{
-    if (object == self && [keyPath isEqualToString:@"frame"] && (!CGSizeEqualToSize(self.bounds.size, CGSizeZero)))
-    {
+- (void)layoutSubviews {
+    // The frame buffer needs to be trashed and re-created when the view size changes.
+    if (!CGSizeEqualToSize(self.bounds.size, boundsSizeAtFrameBufferEpoch) &&
+        !CGSizeEqualToSize(self.bounds.size, CGSizeZero)) {
         runSynchronouslyOnVideoProcessingQueue(^{
             [self destroyDisplayFramebuffer];
             [self createDisplayFramebuffer];
@@ -141,8 +144,6 @@
 
 - (void)dealloc
 {
-    [self removeObserver:self forKeyPath:@"frame"];
-    
     runSynchronouslyOnVideoProcessingQueue(^{
         [self destroyDisplayFramebuffer];
     });
@@ -155,18 +156,18 @@
 {
     [GPUImageContext useImageProcessingContext];
     
-	glGenFramebuffers(1, &displayFramebuffer);
-	glBindFramebuffer(GL_FRAMEBUFFER, displayFramebuffer);
+    glGenFramebuffers(1, &displayFramebuffer);
+    glBindFramebuffer(GL_FRAMEBUFFER, displayFramebuffer);
 	
-	glGenRenderbuffers(1, &displayRenderbuffer);
-	glBindRenderbuffer(GL_RENDERBUFFER, displayRenderbuffer);
+    glGenRenderbuffers(1, &displayRenderbuffer);
+    glBindRenderbuffer(GL_RENDERBUFFER, displayRenderbuffer);
 	
-	[[[GPUImageContext sharedImageProcessingContext] context] renderbufferStorage:GL_RENDERBUFFER fromDrawable:(CAEAGLLayer*)self.layer];
+    [[[GPUImageContext sharedImageProcessingContext] context] renderbufferStorage:GL_RENDERBUFFER fromDrawable:(CAEAGLLayer*)self.layer];
 	
     GLint backingWidth, backingHeight;
 
-	glGetRenderbufferParameteriv(GL_RENDERBUFFER, GL_RENDERBUFFER_WIDTH, &backingWidth);
-	glGetRenderbufferParameteriv(GL_RENDERBUFFER, GL_RENDERBUFFER_HEIGHT, &backingHeight);
+    glGetRenderbufferParameteriv(GL_RENDERBUFFER, GL_RENDERBUFFER_WIDTH, &backingWidth);
+    glGetRenderbufferParameteriv(GL_RENDERBUFFER, GL_RENDERBUFFER_HEIGHT, &backingHeight);
     
     if ( (backingWidth == 0) || (backingHeight == 0) )
     {
@@ -177,12 +178,13 @@
     _sizeInPixels.width = (CGFloat)backingWidth;
     _sizeInPixels.height = (CGFloat)backingHeight;
 
-//	NSLog(@"Backing width: %d, height: %d", backingWidth, backingHeight);
+//    NSLog(@"Backing width: %d, height: %d", backingWidth, backingHeight);
 
-	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, displayRenderbuffer);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, displayRenderbuffer);
 	
     GLuint framebufferCreationStatus = glCheckFramebufferStatus(GL_FRAMEBUFFER);
     NSAssert(framebufferCreationStatus == GL_FRAMEBUFFER_COMPLETE, @"Failure with display framebuffer generation for display of size: %f, %f", self.bounds.size.width, self.bounds.size.height);
+    boundsSizeAtFrameBufferEpoch = self.bounds.size;
 }
 
 - (void)destroyDisplayFramebuffer;


### PR DESCRIPTION
Using KVO on `GPUImageView frame` doesn't seem to work for me on iOS7.

I've changed the approach to rely on `layoutSubviews`, and also to only trash the frame buffer when the width/height of the bounds changes. I think that'll resolve performance problems of issues like #1407.
