### PR TITLE
Fixed the color attachment comparison bug

### DIFF
--- a/framework/Source/GPUImageMovie.m
+++ b/framework/Source/GPUImageMovie.m
@@ -451,7 +451,7 @@
     int bufferWidth = (int) CVPixelBufferGetWidth(movieFrame);
 #endif
     CFTypeRef colorAttachments = CVBufferGetAttachment(movieFrame, kCVImageBufferYCbCrMatrixKey, NULL);
-    if (colorAttachments == kCVImageBufferYCbCrMatrix_ITU_R_601_4) {
+    if(CFStringCompare(colorAttachments, kCVImageBufferYCbCrMatrix_ITU_R_601_4, 0) == kCFCompareEqualTo) {
         _preferredConversion = kColorConversion601;
     }
     else {

--- a/framework/Source/GPUImageVideoCamera.m
+++ b/framework/Source/GPUImageVideoCamera.m
@@ -655,7 +655,7 @@ NSString *const kGPUImageYUVVideoRangeConversionForLAFragmentShaderString = SHAD
     int bufferWidth = (int) CVPixelBufferGetWidth(cameraFrame);
     int bufferHeight = (int) CVPixelBufferGetHeight(cameraFrame);
     CFTypeRef colorAttachments = CVBufferGetAttachment(cameraFrame, kCVImageBufferYCbCrMatrixKey, NULL);
-    if (colorAttachments == kCVImageBufferYCbCrMatrix_ITU_R_601_4) {
+    if(CFStringCompare(colorAttachments, kCVImageBufferYCbCrMatrix_ITU_R_601_4, 0) == kCFCompareEqualTo) {
         _preferredConversion = kColorConversion601;
     }
     else {


### PR DESCRIPTION
Fixes the bug of using the wrong YUV to RGB conversion table while displaying the video from the camera (GPUImageVideoCamera) or playing back a video using the GPUImageMovie class.

In shorts the comparison between two CFStringRef variables was the cause of the problem.

Instead of using CFStringCompare, there was a == comparison which didn't return the correct result.

What is troubling me the most though is that the exact same bug exists in Apple's sample code of '[Real-time Video Processing Using AVPlayerItemVideoOutput](https://developer.apple.com/library/ios/samplecode/AVBasicVideoOutput/Listings/AVBasicVideoOutput_APLEAGLView_m.html#//apple_ref/doc/uid/DTS40013109-AVBasicVideoOutput_APLEAGLView_m-DontLinkElementID_6)' as well, so be advised :)

The bug caused the red color to be displayed as orange (due to the fact that it was using the 709 conversion table instead of the 601 a.k.a. wrong YUV to RGB conversion), as seen from the screenshot below:

![comparison](https://f.cloud.github.com/assets/49122/2430943/bc634c16-ad0e-11e3-86de-7fe2ef0eefbb.jpg)

This bug also affected any rendered movie file from GPUImage that used GPUImageVideoCamera as source.
