### PR TITLE
Fix issue #1451 "GPUImageMovie is leaking with initWithPlayerItem ?"

### DIFF
--- a/framework/Source/GPUImageMovie.m
+++ b/framework/Source/GPUImageMovie.m
@@ -628,13 +628,8 @@
         [synchronizedMovieWriter setVideoInputReadyCallback:^{return NO;}];
         [synchronizedMovieWriter setAudioInputReadyCallback:^{return NO;}];
     }
-
-    runSynchronouslyOnVideoProcessingQueue(^{
-        [displayLink removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
-        displayLink = nil;
-    });
-
-   if ( self.playerItem && displayLink != nil ) {
+    
+    if ( self.playerItem && displayLink != nil ) {
 //        runSynchronouslyOnVideoProcessingQueue(^{
 //            [displayLink removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
 //             displayLink = nil;
@@ -642,7 +637,7 @@
         [displayLink invalidate]; // remove from all run loop
         displayLink = nil;
     }
-
+    
     if ([self.delegate respondsToSelector:@selector(didCompletePlayingMovie)]) {
         [self.delegate didCompletePlayingMovie];
     }


### PR DESCRIPTION
Patch for issue https://github.com/BradLarson/GPUImage/issues/1451

Comments: 
- (CADisplayLink *)displayLinkWithTarget:(id)target selector:(SEL)sel
  so the dealloc of GPUImageMovie method is never called.

https://developer.apple.com/library/ios/documentation/QuartzCore/Reference/CADisplayLink_ClassRef/Reference/Reference.html#//apple_ref/occ/clm/CADisplayLink/displayLinkWithTarget:selector:

In order to release the target it's enough to call [displayLink invalidate] in -(void)endProcessing method.
