### PR TITLE
Fix assertion in GPUImageView when using Autolayout

### DIFF
--- a/framework/Source/iOS/GPUImageView.m
+++ b/framework/Source/iOS/GPUImageView.m
@@ -131,6 +131,8 @@
 }
 
 - (void)layoutSubviews {
+    [super layoutSubviews];
+    
     // The frame buffer needs to be trashed and re-created when the view size changes.
     if (!CGSizeEqualToSize(self.bounds.size, boundsSizeAtFrameBufferEpoch) &&
         !CGSizeEqualToSize(self.bounds.size, CGSizeZero)) {


### PR DESCRIPTION
The following assertion will be thrown when using GPUImageView and Autolayout:
Uncaught exception: Auto Layout still required after executing -layoutSubviews. GPUImageView's implementation of -layoutSubviews needs to call super.
