### PR TITLE
Silence "Variable Unused" warnings when assertions are blocked (Release builds)

### DIFF
--- a/framework/Source/GPUImageFramebuffer.m
+++ b/framework/Source/GPUImageFramebuffer.m
@@ -191,9 +191,11 @@ void dataProviderUnlockCallback (void *info, const void *data, size_t size);
             glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, _texture, 0);
         }
         
+        #ifndef NS_BLOCK_ASSERTIONS
         GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
-        
         NSAssert(status == GL_FRAMEBUFFER_COMPLETE, @"Incomplete filter FBO: %d", status);
+        #endif
+        
         glBindTexture(GL_TEXTURE_2D, 0);
     });
 }

--- a/framework/Source/Mac/GPUImageMovieWriter.m
+++ b/framework/Source/Mac/GPUImageMovieWriter.m
@@ -197,11 +197,13 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
     // custom output settings specified
     else 
     {
+        #ifndef NS_BLOCK_ASSERTIONS
 		NSString *videoCodec = [outputSettings objectForKey:AVVideoCodecKey];
 		NSNumber *width = [outputSettings objectForKey:AVVideoWidthKey];
 		NSNumber *height = [outputSettings objectForKey:AVVideoHeightKey];
 		
 		NSAssert(videoCodec && width && height, @"OutputSettings is missing required parameters.");
+        #endif
     }
     
     /*
@@ -370,9 +372,10 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
     glRenderbufferStorage(GL_RENDERBUFFER, GL_RGBA8, (int)videoSize.width, (int)videoSize.height);
     glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, movieRenderbuffer);	
 	
+    #ifndef NS_BLOCK_ASSERTIONS
 	GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
-    
     NSAssert(status == GL_FRAMEBUFFER_COMPLETE, @"Incomplete filter FBO: %d", status);
+    #endif
 }
 
 - (void)destroyDataFBO;


### PR DESCRIPTION
Only warning left is due to an inexistent method `setContentScaleFactor:` in [GPUImageView.m#L430](https://github.com/BradLarson/GPUImage/blob/6e7fc67cbd6fdd4a43c564539a2614ad0e58fbf7/framework/Source/iOS/GPUImageView.m#L430).
