### PR TITLE
Proper YCbCr to RGB conversion

### DIFF
--- a/framework/Source/GPUImageVideoCamera.h
+++ b/framework/Source/GPUImageVideoCamera.h
@@ -5,8 +5,10 @@
 #import "GPUImageOutput.h"
 
 extern const GLfloat kColorConversion601[];
+extern const GLfloat kColorConversion601FullRange[];
 extern const GLfloat kColorConversion709[];
 extern NSString *const kGPUImageYUVVideoRangeConversionForRGFragmentShaderString;
+extern NSString *const kGPUImageYUVFullRangeConversionForLAFragmentShaderString;
 extern NSString *const kGPUImageYUVVideoRangeConversionForLAFragmentShaderString;
 
 

--- a/framework/Source/iOS/GPUImageMovieWriter.m
+++ b/framework/Source/iOS/GPUImageMovieWriter.m
@@ -517,6 +517,15 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
 
         CVPixelBufferPoolCreatePixelBuffer (NULL, [assetWriterPixelBufferInput pixelBufferPool], &renderTarget);
 
+        /* AVAssetWriter will use BT.601 conversion matrix for RGB to YCbCr conversion
+         * regardless of the kCVImageBufferYCbCrMatrixKey value.
+         * Tagging the resulting video file as BT.601, is the best option right now.
+         * Creating a proper BT.709 video is not possible at the moment.
+         */
+        CVBufferSetAttachment(renderTarget, kCVImageBufferColorPrimariesKey, kCVImageBufferColorPrimaries_ITU_R_709_2, kCVAttachmentMode_ShouldPropagate);
+        CVBufferSetAttachment(renderTarget, kCVImageBufferYCbCrMatrixKey, kCVImageBufferYCbCrMatrix_ITU_R_601_4, kCVAttachmentMode_ShouldPropagate);
+        CVBufferSetAttachment(renderTarget, kCVImageBufferTransferFunctionKey, kCVImageBufferTransferFunction_ITU_R_709_2, kCVAttachmentMode_ShouldPropagate);
+        
         CVOpenGLESTextureCacheCreateTextureFromImage (kCFAllocatorDefault, coreVideoTextureCache, renderTarget,
                                                       NULL, // texture attributes
                                                       GL_TEXTURE_2D,


### PR DESCRIPTION
GPUImage uses 3 different pixel formats: 
- kCVPixelFormatType_420YpCbCr8BiPlanarFullRange
- kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
- kCVPixelFormatType_32BGRA

Each format requires different treatment, depending on the YUV range (video range, full range) and the color standard (BT.601, BT.709). The previous implementation did not take this into account. So different pixel formats resulted in different output and inconsistent color output. 

This pull request, uses 2 different shaders (full range, video range) and the proper YCbCr to RGB conversion matrix according to the pixel format used. This affects the color output of the following sources: GPUImageVideoCamera, GPUImageMovie, GPUImageStillcamera.

Added proper color conversion in the following sources: VideoCamera, Movie:
- corrected the YUVVideoRange shader, so that it subtracts “16” from the “Y” component
- added a YUVFullRange shader
- added “isFullYUVRange” variable so that the proper shader and conversion matrix are selected
- moved the initialization of “yuvConversionProgram” after checking if FullYUVRange is supported (so that the appropriate shader is loaded)

MovieWriter tags the resulting video file as BT.601:
- 3 attachments are added on the “renderTarget” buffer so that AVAssetWriter can use them
