### PR TITLE
updated iOS version reference to avoid explicit release of semaphores on iOS6

### DIFF
--- a/framework/Source/GPUImageFilter.m
+++ b/framework/Source/GPUImageFilter.m
@@ -70,7 +70,8 @@ NSString *const kGPUImagePassthroughFragmentShaderString = SHADER_STRING
     backgroundColorGreen = 0.0;
     backgroundColorBlue = 0.0;
     backgroundColorAlpha = 0.0;
-    imageCaptureSemaphore = dispatch_semaphore_create(1);
+    imageCaptureSemaphore = dispatch_semaphore_create(0);
+    dispatch_semaphore_signal(imageCaptureSemaphore);
 
     runSynchronouslyOnVideoProcessingQueue(^{
         [GPUImageContext useImageProcessingContext];

--- a/framework/Source/iOS/GPUImagePicture.m
+++ b/framework/Source/iOS/GPUImagePicture.m
@@ -62,8 +62,10 @@
     
     hasProcessedImage = NO;
     self.shouldSmoothlyScaleOutput = smoothlyScaleOutput;
-    imageUpdateSemaphore = dispatch_semaphore_create(1);
-    
+    imageUpdateSemaphore = dispatch_semaphore_create(0);
+    dispatch_semaphore_signal(imageUpdateSemaphore);
+
+
     // TODO: Dispatch this whole thing asynchronously to move image loading off main thread
     CGFloat widthOfImage = CGImageGetWidth(newImageSource);
     CGFloat heightOfImage = CGImageGetHeight(newImageSource);


### PR DESCRIPTION
It appears that dispatch_release could be compiled into a build with deployment target=iOS6, causing compilation errors.
