### PR TITLE
`dispatch_release` excluded on 6.0+ (instead of 7.0+)

### DIFF
--- a/framework/Source/GPUImageFilter.m
+++ b/framework/Source/GPUImageFilter.m
@@ -155,7 +155,7 @@ NSString *const kGPUImagePassthroughFragmentShaderString = SHADER_STRING
 
 - (void)dealloc
 {
-#if ( (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_7_0) || (!defined(__IPHONE_7_0)) )
+#if ( (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_6_0) || (!defined(__IPHONE_6_0)) )
     if (imageCaptureSemaphore != NULL)
     {
         dispatch_release(imageCaptureSemaphore);

--- a/framework/Source/iOS/GPUImagePicture.m
+++ b/framework/Source/iOS/GPUImagePicture.m
@@ -216,7 +216,7 @@
     [outputFramebuffer enableReferenceCounting];
     [outputFramebuffer unlock];
 
-#if ( (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_7_0) || (!defined(__IPHONE_7_0)) )
+#if ( (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_6_0) || (!defined(__IPHONE_6_0)) )
     if (imageUpdateSemaphore != NULL)
     {
         dispatch_release(imageUpdateSemaphore);


### PR DESCRIPTION
Changed `#if` wrapping around `dispatch_release` to check for iOS 6.0 or newer, rather than 7.0 or newer.

This fixes errors:
- `error: 'release' is unavailable: not available in automatic reference counting mode`
- `ARC forbids explicit message send of 'release'`

occurring on the `dispatch_release` call when compiling against iOS 6.x (checked on iOS 6.1; assumed the problem is 6.0+-relevant based on https://github.com/ReactiveCocoa/ReactiveCocoa/issues/204 and https://github.com/Nyx0uf/NYXImagesKit/issues/16).

Resolves BradLarson/GPUImage#1528
