### PR TITLE
Add method to remove filter using only the filter

### DIFF
--- a/framework/Source/GPUImageFilterPipeline.h
+++ b/framework/Source/GPUImageFilterPipeline.h
@@ -19,6 +19,7 @@
 - (void) addFilter:(GPUImageFilter*)filter atIndex:(NSUInteger)insertIndex;
 - (void) replaceFilterAtIndex:(NSUInteger)index withFilter:(GPUImageFilter*)filter;
 - (void) replaceAllFilters:(NSArray*) newFilters;
+- (void) removeFilter:(GPUImageFilter*)filter;
 - (void) removeFilterAtIndex:(NSUInteger)index;
 - (void) removeAllFilters;
 

--- a/framework/Source/GPUImageFilterPipeline.m
+++ b/framework/Source/GPUImageFilterPipeline.m
@@ -163,6 +163,12 @@
     [self _refreshFilters];
 }
 
+- (void)removeFilter:(GPUImageFilter *)filter
+{
+    [self.filters removeObject:filter];
+    [self _refreshFilters];
+}
+
 - (void)removeFilterAtIndex:(NSUInteger)index {
     [self.filters removeObjectAtIndex:index];
     [self _refreshFilters];


### PR DESCRIPTION
Adds a method to remove a filter using the `removeObject:` method of the mutable filters array.
