### PR TITLE
Change filter input and outputs to the base class

### DIFF
--- a/framework/Source/GPUImageFilterPipeline.h
+++ b/framework/Source/GPUImageFilterPipeline.h
@@ -1,5 +1,8 @@
 #import <Foundation/Foundation.h>
-#import "GPUImageFilter.h"
+#import <UIKit/UIKit.h>
+
+@class GPUImageOutput;
+@protocol GPUImageInput;
 
 @interface GPUImageFilterPipeline : NSObject
 {
@@ -15,9 +18,9 @@
 - (id) initWithConfiguration:(NSDictionary*) configuration input:(GPUImageOutput*)input output:(id <GPUImageInput>)output;
 - (id) initWithConfigurationFile:(NSURL*) configuration input:(GPUImageOutput*)input output:(id <GPUImageInput>)output;
 
-- (void) addFilter:(GPUImageFilter*)filter;
-- (void) addFilter:(GPUImageFilter*)filter atIndex:(NSUInteger)insertIndex;
-- (void) replaceFilterAtIndex:(NSUInteger)index withFilter:(GPUImageFilter*)filter;
+- (void) addFilter:(GPUImageOutput<GPUImageInput> *)filter;
+- (void) addFilter:(GPUImageOutput<GPUImageInput> *)filter atIndex:(NSUInteger)insertIndex;
+- (void) replaceFilterAtIndex:(NSUInteger)index withFilter:(GPUImageOutput<GPUImageInput> *)filter;
 - (void) replaceAllFilters:(NSArray*) newFilters;
 - (void) removeFilterAtIndex:(NSUInteger)index;
 - (void) removeAllFilters;

--- a/framework/Source/GPUImageFilterPipeline.m
+++ b/framework/Source/GPUImageFilterPipeline.m
@@ -1,4 +1,5 @@
 #import "GPUImageFilterPipeline.h"
+#import "GPUImageOutput.h"
 
 @interface GPUImageFilterPipeline ()
 
@@ -48,7 +49,7 @@
     for (NSDictionary *filter in filters) {
         NSString *filterName = [filter objectForKey:@"FilterName"];
         Class theClass = NSClassFromString(filterName);
-        GPUImageFilter *genericFilter = [[theClass alloc] init];
+        GPUImageOutput<GPUImageInput> *genericFilter = [[theClass alloc] init];
         // Set up the properties
         NSDictionary *filterAttributes;
         if ((filterAttributes = [filter objectForKey:@"Attributes"])) {
@@ -148,17 +149,17 @@
     return self;
 }
 
-- (void)addFilter:(GPUImageFilter *)filter atIndex:(NSUInteger)insertIndex {
+- (void)addFilter:(GPUImageOutput<GPUImageInput> *)filter atIndex:(NSUInteger)insertIndex {
     [self.filters insertObject:filter atIndex:insertIndex];
     [self _refreshFilters];
 }
 
-- (void)addFilter:(GPUImageFilter *)filter {
+- (void)addFilter:(GPUImageOutput<GPUImageInput> *)filter {
     [self.filters addObject:filter];
     [self _refreshFilters];
 }
 
-- (void)replaceFilterAtIndex:(NSUInteger)index withFilter:(GPUImageFilter *)filter {
+- (void)replaceFilterAtIndex:(NSUInteger)index withFilter:(GPUImageOutput<GPUImageInput> *)filter {
     [self.filters replaceObjectAtIndex:index withObject:filter];
     [self _refreshFilters];
 }
@@ -181,7 +182,7 @@
 - (void)_refreshFilters {
     
     id prevFilter = self.input;
-    GPUImageFilter *theFilter = nil;
+    GPUImageOutput<GPUImageInput> *theFilter = nil;
     
     for (int i = 0; i < [self.filters count]; i++) {
         theFilter = [self.filters objectAtIndex:i];
@@ -198,15 +199,15 @@
 }
 
 - (UIImage *)currentFilteredFrame {
-    return [(GPUImageFilter *)[_filters lastObject] imageFromCurrentFramebuffer];
+    return [(GPUImageOutput<GPUImageInput> *)[_filters lastObject] imageFromCurrentFramebuffer];
 }
 
 - (UIImage *)currentFilteredFrameWithOrientation:(UIImageOrientation)imageOrientation {
-  return [(GPUImageFilter *)[_filters lastObject] imageFromCurrentFramebufferWithOrientation:imageOrientation];
+  return [(GPUImageOutput<GPUImageInput> *)[_filters lastObject] imageFromCurrentFramebufferWithOrientation:imageOrientation];
 }
 
 - (CGImageRef)newCGImageFromCurrentFilteredFrame {
-    return [(GPUImageFilter *)[_filters lastObject] newCGImageFromCurrentlyProcessedOutput];
+    return [(GPUImageOutput<GPUImageInput> *)[_filters lastObject] newCGImageFromCurrentlyProcessedOutput];
 }
 
 @end


### PR DESCRIPTION
Currently the pipeline class uses `GPUImageFilter` as the class for adding, removing, etc filters.  Filters do not derive from that class so you have to cast filters to that class when you add or remove them.  It should instead use the base class of all filters `GPUImageOutput<GPUImageInput>` so no casting has to happen.  This is the way `GPUImageFilterGroup` works and the pipeline is similar in that it groups together filters.
