### PR TITLE
fix memory access issues when working with CVPixelBuffer-backed framebuffer

### DIFF
--- a/framework/Source/GPUImageFramebuffer.h
+++ b/framework/Source/GPUImageFramebuffer.h
@@ -50,6 +50,8 @@ typedef struct GPUTextureOptions {
 - (void)restoreRenderTarget;
 
 // Raw data bytes
+- (void)lockForReading;
+- (void)unlockAfterReading;
 - (NSUInteger)bytesPerRow;
 - (GLubyte *)byteBuffer;
 

--- a/framework/Source/GPUImageFramebuffer.m
+++ b/framework/Source/GPUImageFramebuffer.m
@@ -7,6 +7,7 @@
 #if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
     CVPixelBufferRef renderTarget;
     CVOpenGLESTextureRef renderTexture;
+    NSUInteger readLockCount;
 #else
 #endif
     NSUInteger framebufferReferenceCount;
@@ -331,7 +332,7 @@ void dataProviderUnlockCallback (void *info, const void *data, size_t size)
             //        glFlush();
             glFinish();
             CFRetain(renderTarget); // I need to retain the pixel buffer here and release in the data source callback to prevent its bytes from being prematurely deallocated during a photo write operation
-            CVPixelBufferLockBaseAddress(renderTarget, 0);
+            [self lockForReading];
             rawImagePixels = (GLubyte *)CVPixelBufferGetBaseAddress(renderTarget);
             dataProvider = CGDataProviderCreateWithData((__bridge_retained void*)self, rawImagePixels, paddedBytesForImage, dataProviderUnlockCallback);
             [[GPUImageContext sharedFramebufferCache] addFramebufferToActiveImageCaptureList:self]; // In case the framebuffer is swapped out on the filter, need to have a strong reference to it somewhere for it to hang on while the image is in existence
@@ -373,7 +374,7 @@ void dataProviderUnlockCallback (void *info, const void *data, size_t size)
 - (void)restoreRenderTarget;
 {
 #if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
-    CVPixelBufferUnlockBaseAddress(renderTarget, 0);
+    [self unlockAfterReading];
     CFRelease(renderTarget);
 #else
 #endif
@@ -381,6 +382,35 @@ void dataProviderUnlockCallback (void *info, const void *data, size_t size)
 
 #pragma mark -
 #pragma mark Raw data bytes
+
+- (void)lockForReading
+{
+#if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
+    if ([GPUImageContext supportsFastTextureUpload])
+    {
+        if (readLockCount == 0)
+        {
+            CVPixelBufferLockBaseAddress(renderTarget, 0);
+        }
+        readLockCount++;
+    }
+#endif
+}
+
+- (void)unlockAfterReading
+{
+#if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
+    if ([GPUImageContext supportsFastTextureUpload])
+    {
+        NSAssert(readLockCount > 0, @"Unbalanced call to -[GPUImageFramebuffer unlockAfterReading]");
+        readLockCount--;
+        if (readLockCount == 0)
+        {
+            CVPixelBufferUnlockBaseAddress(renderTarget, 0);
+        }
+    }
+#endif
+}
 
 - (NSUInteger)bytesPerRow;
 {
@@ -401,9 +431,9 @@ void dataProviderUnlockCallback (void *info, const void *data, size_t size)
 - (GLubyte *)byteBuffer;
 {
 #if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
-    CVPixelBufferLockBaseAddress(renderTarget, 0);
+    [self lockForReading];
     GLubyte * bufferBytes = CVPixelBufferGetBaseAddress(renderTarget);
-    CVPixelBufferUnlockBaseAddress(renderTarget, 0);
+    [self unlockAfterReading];
     return bufferBytes;
 #else
     return NULL; // TODO: do more with this on the non-texture-cache side

--- a/framework/Source/GPUImageRawDataOutput.m
+++ b/framework/Source/GPUImageRawDataOutput.m
@@ -106,6 +106,8 @@
     if(lockNextFramebuffer)
     {
         retainedFramebuffer = outputFramebuffer;
+        [retainedFramebuffer lock];
+        [retainedFramebuffer lockForReading];
         lockNextFramebuffer = NO;
     }
 
@@ -297,6 +299,7 @@
 
 - (void)unlockFramebufferAfterReading;
 {
+    [retainedFramebuffer unlockAfterReading];
     [retainedFramebuffer unlock];
     retainedFramebuffer = nil;
 }


### PR DESCRIPTION
Currently `GPUImageRawDataOutput` provides `rawBytesForImage` property for getting output data buffer, however accessing it may cause a crash if the texture is backed by `CVPixelBuffer` because
any reads fmust be preceded by a call to  `CVPixelBufferLockBaseAddress`.
This patch fixes the bad access issue (assuming that data processing is wrapped in calls to `lockFramebufferForReading` and `unlockFramebufferAfterReading`)

Besides there was a mistake with framebuffer reference counting: `lockFramebufferForReading` did
not really cause the retained buffer to be retained, so calling `unlockFramebufferAfterReading` afterward
caused a crash due to over-release.
