### PR TITLE
Fix setFloatArray:... so that it copies the data in case it's on the stack

### DIFF
--- a/framework/Source/GPUImageFilter.m
+++ b/framework/Source/GPUImageFilter.m
@@ -512,11 +512,14 @@ NSString *const kGPUImagePassthroughFragmentShaderString = SHADER_STRING
 
 - (void)setFloatArray:(GLfloat *)arrayValue length:(GLsizei)arrayLength forUniform:(GLint)uniform program:(GLProgram *)shaderProgram;
 {
+    // Make a copy of the data, so it doesn't get overwritten before async call executes
+    NSData* arrayData = [NSData dataWithBytes:arrayValue length:arrayLength * sizeof(arrayValue[0])];
+
     runAsynchronouslyOnVideoProcessingQueue(^{
         [GPUImageContext setActiveShaderProgram:shaderProgram];
         
         [self setAndExecuteUniformStateCallbackAtIndex:uniform forProgram:shaderProgram toBlock:^{
-            glUniform1fv(uniform, arrayLength, arrayValue);
+            glUniform1fv(uniform, arrayLength, [arrayData bytes]);
         }];
     });
 }


### PR DESCRIPTION
The function previously relied on `arrayValue' remaining in place long
enough for the async call to read it, which doesn't always happen,
especially if it was allocated on the stack.

I think this also was the cause of https://github.com/BradLarson/GPUImage/issues/847
