### PR TITLE
Add category on GPUImagePicture to allow replacing the texture with a subimage

### DIFF
--- a/framework/GPUImage.xcodeproj/project.pbxproj
+++ b/framework/GPUImage.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		83AE9F991540DFE500F7FC13 /* GPUImageSubtractBlendFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 83AE9F971540DFE500F7FC13 /* GPUImageSubtractBlendFilter.m */; };
 		83AE9FCD1540E92800F7FC13 /* GPUImageMaskFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 83AE9FCB1540E92800F7FC13 /* GPUImageMaskFilter.h */; };
 		83AE9FCE1540E92800F7FC13 /* GPUImageMaskFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 83AE9FCC1540E92800F7FC13 /* GPUImageMaskFilter.m */; };
+		84FFC80B1936408F00994258 /* GPUImagePicture+TextureSubimage.h in Headers */ = {isa = PBXBuildFile; fileRef = 84FFC8091936408F00994258 /* GPUImagePicture+TextureSubimage.h */; };
+		84FFC80C1936408F00994258 /* GPUImagePicture+TextureSubimage.m in Sources */ = {isa = PBXBuildFile; fileRef = 84FFC80A1936408F00994258 /* GPUImagePicture+TextureSubimage.m */; };
 		96781B2F15C38DCF005FA0D7 /* GPUImageAmatorkaFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 96781B2D15C38DCF005FA0D7 /* GPUImageAmatorkaFilter.h */; };
 		96781B3015C38DCF005FA0D7 /* GPUImageAmatorkaFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 96781B2E15C38DCF005FA0D7 /* GPUImageAmatorkaFilter.m */; };
 		96781B3415C39E80005FA0D7 /* GPUImageMissEtikateFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 96781B3215C39E80005FA0D7 /* GPUImageMissEtikateFilter.h */; };
@@ -393,6 +395,8 @@
 		83AE9F971540DFE500F7FC13 /* GPUImageSubtractBlendFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = GPUImageSubtractBlendFilter.m; path = Source/GPUImageSubtractBlendFilter.m; sourceTree = SOURCE_ROOT; };
 		83AE9FCB1540E92800F7FC13 /* GPUImageMaskFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GPUImageMaskFilter.h; path = Source/GPUImageMaskFilter.h; sourceTree = SOURCE_ROOT; };
 		83AE9FCC1540E92800F7FC13 /* GPUImageMaskFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = GPUImageMaskFilter.m; path = Source/GPUImageMaskFilter.m; sourceTree = SOURCE_ROOT; };
+		84FFC8091936408F00994258 /* GPUImagePicture+TextureSubimage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "GPUImagePicture+TextureSubimage.h"; path = "Source/iOS/GPUImagePicture+TextureSubimage.h"; sourceTree = SOURCE_ROOT; };
+		84FFC80A1936408F00994258 /* GPUImagePicture+TextureSubimage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "GPUImagePicture+TextureSubimage.m"; path = "Source/iOS/GPUImagePicture+TextureSubimage.m"; sourceTree = SOURCE_ROOT; };
 		96781B2D15C38DCF005FA0D7 /* GPUImageAmatorkaFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GPUImageAmatorkaFilter.h; path = Source/GPUImageAmatorkaFilter.h; sourceTree = SOURCE_ROOT; };
 		96781B2E15C38DCF005FA0D7 /* GPUImageAmatorkaFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = GPUImageAmatorkaFilter.m; path = Source/GPUImageAmatorkaFilter.m; sourceTree = SOURCE_ROOT; };
 		96781B3215C39E80005FA0D7 /* GPUImageMissEtikateFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GPUImageMissEtikateFilter.h; path = Source/GPUImageMissEtikateFilter.h; sourceTree = SOURCE_ROOT; };
@@ -979,6 +983,8 @@
 				BC7D95D41523EE67000DF037 /* GPUImageStillCamera.m */,
 				BCB5E7D814E6003400701302 /* GPUImagePicture.h */,
 				BCB5E7D914E6003400701302 /* GPUImagePicture.m */,
+				84FFC8091936408F00994258 /* GPUImagePicture+TextureSubimage.h */,
+				84FFC80A1936408F00994258 /* GPUImagePicture+TextureSubimage.m */,
 				BC982C6A14F33C290001FF6F /* GPUImageMovie.h */,
 				BC982C6B14F33C2A0001FF6F /* GPUImageMovie.m */,
 				D443237817C81C0C00204484 /* GPUImageMovieComposition.h */,
@@ -1349,6 +1355,7 @@
 				BC8A584B18131E4B00E6B507 /* GPUImageLuminanceRangeFilter.h in Headers */,
 				C04C8D1715F8059F00449601 /* GPUImageColorBlendFilter.h in Headers */,
 				B80171E616311FCB001C8D16 /* GPUImageHueBlendFilter.h in Headers */,
+				84FFC80B1936408F00994258 /* GPUImagePicture+TextureSubimage.h in Headers */,
 				B80171FE16312800001C8D16 /* GPUImageSaturationBlendFilter.h in Headers */,
 				B801722F16313151001C8D16 /* GPUImageLuminosityBlendFilter.h in Headers */,
 				BC185E7A16B866AD00EA01AD /* GPUImageLinearBurnBlendFilter.h in Headers */,
@@ -1630,6 +1637,7 @@
 				BC185E8316B866F000EA01AD /* GPUImagePixellatePositionFilter.m in Sources */,
 				46A8097916B8A48E000C29ED /* GPUImageTwoInputCrossTextureSamplingFilter.m in Sources */,
 				BC61F4B116B9CAEB009F6234 /* GPUImagePoissonBlendFilter.m in Sources */,
+				84FFC80C1936408F00994258 /* GPUImagePicture+TextureSubimage.m in Sources */,
 				BCBC604E16C58B0900B11741 /* GPUImageMotionBlurFilter.m in Sources */,
 				BCBC605816C8527C00B11741 /* GPUImageZoomBlurFilter.m in Sources */,
 				BCBF617B16E4F44700E2784A /* GPUImageKuwaharaRadius3Filter.m in Sources */,

--- a/framework/Source/iOS/GPUImagePicture+TextureSubimage.h
+++ b/framework/Source/iOS/GPUImagePicture+TextureSubimage.h
@@ -1,0 +1,19 @@
+//
+//  GPUImagePicture+TextureSubimage.h
+//  GPUImage
+//
+//  Created by Jack Wu on 2014-05-28.
+//  Copyright (c) 2014 Brad Larson. All rights reserved.
+//
+
+#import "GPUImagePicture.h"
+
+@interface GPUImagePicture (TextureSubimage)
+
+- (void)replaceTextureWithSubimage:(UIImage*)subimage;
+- (void)replaceTextureWithSubCGImage:(CGImageRef)subimageSource;
+
+- (void)replaceTextureWithSubimage:(UIImage*)subimage inRect:(CGRect)subRect;
+- (void)replaceTextureWithSubCGImage:(CGImageRef)subimageSource inRect:(CGRect)subRect;
+
+@end

--- a/framework/Source/iOS/GPUImagePicture+TextureSubimage.m
+++ b/framework/Source/iOS/GPUImagePicture+TextureSubimage.m
@@ -44,6 +44,9 @@
     CGBitmapInfo bitmapInfo = CGImageGetBitmapInfo(subimageSource);
     CGBitmapInfo byteOrderInfo = bitmapInfo & kCGBitmapByteOrderMask;
     if (byteOrderInfo != kCGBitmapByteOrderDefault && byteOrderInfo != kCGBitmapByteOrder32Big) {
+        shouldRedrawUsingCoreGraphics = YES;
+    }
+    else {
         CGImageAlphaInfo alphaInfo = bitmapInfo & kCGBitmapAlphaInfoMask;
         if (alphaInfo != kCGImageAlphaPremultipliedLast && alphaInfo != kCGImageAlphaLast && alphaInfo != kCGImageAlphaNoneSkipLast) {
             shouldRedrawUsingCoreGraphics = YES;

--- a/framework/Source/iOS/GPUImagePicture+TextureSubimage.m
+++ b/framework/Source/iOS/GPUImagePicture+TextureSubimage.m
@@ -28,8 +28,8 @@
     NSAssert(self.framebufferForOutput.textureOptions.internalFormat == GL_RGBA, @"For replacing subtexture the internal texture format must be GL_RGBA.");
 
     CGRect subimageRect = (CGRect){.origin = CGPointZero, .size = (CGSize){.width = CGImageGetWidth(subimageSource), .height = CGImageGetHeight(subimageSource)}};
-    NSAssert(CGRectIsEmpty(subimageRect), @"Passed sub image must not be empty - it should be at least 1px tall and wide");
-    NSAssert(CGRectIsEmpty(subRect), @"Passed sub rect must not be empty");
+    NSAssert(!CGRectIsEmpty(subimageRect), @"Passed sub image must not be empty - it should be at least 1px tall and wide");
+    NSAssert(!CGRectIsEmpty(subRect), @"Passed sub rect must not be empty");
 
     NSAssert(CGSizeEqualToSize(subimageRect.size, subRect.size), @"Subimage size must match the size of sub rect");
     

--- a/framework/Source/iOS/GPUImagePicture+TextureSubimage.m
+++ b/framework/Source/iOS/GPUImagePicture+TextureSubimage.m
@@ -1,0 +1,100 @@
+//
+//  GPUImagePicture+TextureSubimage.m
+//  GPUImage
+//
+//  Created by Jack Wu on 2014-05-28.
+//  Copyright (c) 2014 Brad Larson. All rights reserved.
+//
+
+#import "GPUImagePicture+TextureSubimage.h"
+
+@implementation GPUImagePicture (TextureSubimage)
+
+- (void)replaceTextureWithSubimage:(UIImage*)subimage {
+    return [self replaceTextureWithSubCGImage:[subimage CGImage]];
+}
+
+- (void)replaceTextureWithSubCGImage:(CGImageRef)subimageSource {
+    CGRect rect = (CGRect) {.origin = CGPointZero, .size = (CGSize){.width = CGImageGetWidth(subimageSource), .height = CGImageGetHeight(subimageSource)}};
+    return [self replaceTextureWithSubCGImage:subimageSource inRect:rect];
+}
+
+- (void)replaceTextureWithSubimage:(UIImage*)subimage inRect:(CGRect)subRect {
+    return [self replaceTextureWithSubCGImage:[subimage CGImage] inRect:subRect];
+}
+
+- (void)replaceTextureWithSubCGImage:(CGImageRef)subimageSource inRect:(CGRect)subRect {
+    NSAssert(outputFramebuffer, @"Picture must be initialized first before replacing subtexture");
+    NSAssert(self.framebufferForOutput.textureOptions.internalFormat == GL_RGBA, @"For replacing subtexture the internal texture format must be GL_RGBA.");
+
+    CGRect subimageRect = (CGRect){.origin = CGPointZero, .size = (CGSize){.width = CGImageGetWidth(subimageSource), .height = CGImageGetHeight(subimageSource)}};
+    NSAssert(CGRectIsEmpty(subimageRect), @"Passed sub image must not be empty - it should be at least 1px tall and wide");
+    NSAssert(CGRectIsEmpty(subRect), @"Passed sub rect must not be empty");
+
+    NSAssert(CGSizeEqualToSize(subimageRect.size, subRect.size), @"Subimage size must match the size of sub rect");
+    
+    // We don't have to worry about scaling the subimage or finding a power of two size.
+    // The initialization has taken care of that for us.
+    
+    dispatch_semaphore_signal(imageUpdateSemaphore);
+
+    BOOL shouldRedrawUsingCoreGraphics = NO;
+
+    // Since internal format is always RGBA, we need the input data in RGBA as well.
+    CGBitmapInfo bitmapInfo = CGImageGetBitmapInfo(subimageSource);
+    CGBitmapInfo byteOrderInfo = bitmapInfo & kCGBitmapByteOrderMask;
+    if (byteOrderInfo != kCGBitmapByteOrderDefault && byteOrderInfo != kCGBitmapByteOrder32Big) {
+        CGImageAlphaInfo alphaInfo = bitmapInfo & kCGBitmapAlphaInfoMask;
+        if (alphaInfo != kCGImageAlphaPremultipliedLast && alphaInfo != kCGImageAlphaLast && alphaInfo != kCGImageAlphaNoneSkipLast) {
+            shouldRedrawUsingCoreGraphics = YES;
+        }
+    }
+
+    GLubyte *imageData = NULL;
+    CFDataRef dataFromImageDataProvider;
+    if (shouldRedrawUsingCoreGraphics)
+    {
+        // For resized or incompatible image: redraw
+        imageData = (GLubyte *) calloc(1, (int)subimageRect.size.width * (int)subimageRect.size.height * 4);
+        
+        CGColorSpaceRef genericRGBColorspace = CGColorSpaceCreateDeviceRGB();
+        
+        CGContextRef imageContext = CGBitmapContextCreate(imageData, (size_t)subimageRect.size.width, (size_t)subimageRect.size.height, 8, (size_t)subimageRect.size.width * 4, genericRGBColorspace,  kCGBitmapByteOrderDefault | kCGImageAlphaPremultipliedLast);
+        
+        CGContextDrawImage(imageContext, CGRectMake(0.0, 0.0, subimageRect.size.width, subimageRect.size.height), subimageSource);
+        CGContextRelease(imageContext);
+        CGColorSpaceRelease(genericRGBColorspace);
+    }
+    else
+    {
+        // Access the raw image bytes directly
+        dataFromImageDataProvider = CGDataProviderCopyData(CGImageGetDataProvider(subimageSource));
+        imageData = (GLubyte *)CFDataGetBytePtr(dataFromImageDataProvider);
+    }
+    
+    runSynchronouslyOnVideoProcessingQueue(^{
+        [GPUImageContext useImageProcessingContext];
+        [outputFramebuffer disableReferenceCounting];
+        
+        glBindTexture(GL_TEXTURE_2D, [outputFramebuffer texture]);
+        
+        // no need to use self.outputTextureOptions here since pictures need this texture formats and type
+        glTexSubImage2D(GL_TEXTURE_2D, 0, subRect.origin.x, subRect.origin.y, (GLint)subRect.size.width, subRect.size.height, GL_RGBA, GL_UNSIGNED_BYTE, imageData);
+        
+        if (self.shouldSmoothlyScaleOutput)
+        {
+            glGenerateMipmap(GL_TEXTURE_2D);
+        }
+        glBindTexture(GL_TEXTURE_2D, 0);
+    });
+
+    if (shouldRedrawUsingCoreGraphics)
+    {
+        free(imageData);
+    }
+    else
+    {
+        CFRelease(dataFromImageDataProvider);
+    }
+}
+@end


### PR DESCRIPTION
This allows better memory management in terms of textures and easier re-using of GPUImagePicture's

Also has performance benefits when using a smaller sub-rect.
When you use subtexture replace, targets and options are kept for the GPUImagePicture which is also convenient.
