### PR TITLE
Fixed realtime video recording

### DIFF
--- a/framework/Source/iOS/GPUImageMovieWriter.m
+++ b/framework/Source/iOS/GPUImageMovieWriter.m
@@ -254,7 +254,6 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
 - (void)startRecording;
 {
     alreadyFinishedRecording = NO;
-    isRecording = YES;
     startTime = kCMTimeInvalid;
     runSynchronouslyOnContextQueue(_movieWriterContext, ^{
         if (audioInputReadyCallback == NULL)
@@ -262,6 +261,7 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
             [assetWriter startWriting];
         }
     });
+    isRecording = YES;
 	//    [assetWriter startSessionAtSourceTime:kCMTimeZero];
 }
 


### PR DESCRIPTION
When realtime video recording,  `newFrameReadyAtTime:atIndex:` and `startRecording` in GPUImageMovieWriter may be called on other thread. 
So `startWriting` in `startRecording` called after `startWriting` in `newFrameReadyAtTime:atIndex:` sometime.
It causes error.
Setting `isRecording` to `YES` after finished `startRecording` fixes issue.
