### PR TITLE
Fixed incorrectly rotated images in Mosaic Filter.

### DIFF
--- a/examples/iOS/FilterShowcase/FilterShowcase/ShowcaseFilterViewController.m
+++ b/examples/iOS/FilterShowcase/FilterShowcase/ShowcaseFilterViewController.m
@@ -882,9 +882,7 @@
             [(GPUImageMosaicFilter *)filter setColorOn:NO];
             //[(GPUImageMosaicFilter *)filter setTileSet:@"dotletterstiles.png"];
             //[(GPUImageMosaicFilter *)filter setTileSet:@"curvies.png"]; 
-            
-            [filter setInputRotation:kGPUImageRotateRight atIndex:0];
-            
+                        
         }; break;
         case GPUIMAGE_CHROMAKEY:
         {


### PR DESCRIPTION
The Mosaic Filter example in the Filter Showcase app incorrectly rotates the image to the right.

Removing the `setInputRotation` line fixes the issue.
