### PR TITLE
added sourceFormatHint for audio input in GPUImageMovieWriter

### DIFF
--- a/framework/Source/Mac/GPUImageMovieWriter.h
+++ b/framework/Source/Mac/GPUImageMovieWriter.h
@@ -44,6 +44,7 @@ extern NSString *const kGPUImageColorSwizzlingFragmentShaderString;
 - (id)initWithMovieURL:(NSURL *)newMovieURL size:(CGSize)newSize fileType:(NSString *)newFileType outputSettings:(NSMutableDictionary *)outputSettings;
 
 - (void)setHasAudioTrack:(BOOL)hasAudioTrack audioSettings:(NSDictionary *)audioOutputSettings;
+- (void)setHasAudioTrack:(BOOL)hasAudioTrack audioSettings:(NSDictionary *)audioOutputSettings sourceFormatHint:(CMFormatDescriptionRef)sourceFormatHint;
 
 // Movie recording
 - (void)startRecording;

--- a/framework/Source/Mac/GPUImageMovieWriter.m
+++ b/framework/Source/Mac/GPUImageMovieWriter.m
@@ -588,7 +588,11 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
 	[self setHasAudioTrack:newValue audioSettings:nil];
 }
 
-- (void)setHasAudioTrack:(BOOL)newValue audioSettings:(NSDictionary *)audioOutputSettings;
+- (void)setHasAudioTrack:(BOOL)hasAudioTrack audioSettings:(NSDictionary *)audioOutputSettings {
+    [self setHasAudioTrack:hasAudioTrack audioSettings:audioOutputSettings sourceFormatHint:NULL];
+}
+
+- (void)setHasAudioTrack:(BOOL)newValue audioSettings:(NSDictionary *)audioOutputSettings sourceFormatHint:(CMFormatDescriptionRef)sourceFormatHint
 {
     _hasAudioTrack = newValue;
     
@@ -630,7 +634,11 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
                                    nil];*/
         }
         
-        assetWriterAudioInput = [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeAudio outputSettings:audioOutputSettings];
+        if ([AVAssetWriterInput respondsToSelector:@selector(assetWriterInputWithMediaType:outputSettings:sourceFormatHint:)]) {
+            assetWriterAudioInput = [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeAudio outputSettings:audioOutputSettings sourceFormatHint:sourceFormatHint];
+        } else {
+            assetWriterAudioInput = [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeAudio outputSettings:audioOutputSettings];
+        }
         [assetWriter addInput:assetWriterAudioInput];
         assetWriterAudioInput.expectsMediaDataInRealTime = _encodingLiveVideo;
     }

--- a/framework/Source/iOS/GPUImageMovieWriter.h
+++ b/framework/Source/iOS/GPUImageMovieWriter.h
@@ -53,6 +53,7 @@ extern NSString *const kGPUImageColorSwizzlingFragmentShaderString;
 - (id)initWithMovieURL:(NSURL *)newMovieURL size:(CGSize)newSize fileType:(NSString *)newFileType outputSettings:(NSDictionary *)outputSettings;
 
 - (void)setHasAudioTrack:(BOOL)hasAudioTrack audioSettings:(NSDictionary *)audioOutputSettings;
+- (void)setHasAudioTrack:(BOOL)hasAudioTrack audioSettings:(NSDictionary *)audioOutputSettings sourceFormatHint:(CMFormatDescriptionRef)sourceFormatHint;
 
 // Movie recording
 - (void)startRecording;

--- a/framework/Source/iOS/GPUImageMovieWriter.m
+++ b/framework/Source/iOS/GPUImageMovieWriter.m
@@ -801,7 +801,11 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
 	[self setHasAudioTrack:newValue audioSettings:nil];
 }
 
-- (void)setHasAudioTrack:(BOOL)newValue audioSettings:(NSDictionary *)audioOutputSettings;
+- (void)setHasAudioTrack:(BOOL)hasAudioTrack audioSettings:(NSDictionary *)audioOutputSettings {
+    [self setHasAudioTrack:hasAudioTrack audioSettings:audioOutputSettings sourceFormatHint:NULL];
+}
+
+- (void)setHasAudioTrack:(BOOL)newValue audioSettings:(NSDictionary *)audioOutputSettings sourceFormatHint:(CMFormatDescriptionRef)sourceFormatHint
 {
     _hasAudioTrack = newValue;
     
@@ -855,7 +859,12 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
                                    nil];*/
         }
         
-        assetWriterAudioInput = [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeAudio outputSettings:audioOutputSettings];
+        if ([AVAssetWriterInput respondsToSelector:@selector(assetWriterInputWithMediaType:outputSettings:sourceFormatHint:)]) {
+            assetWriterAudioInput = [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeAudio outputSettings:audioOutputSettings sourceFormatHint:sourceFormatHint];
+        } else {
+            assetWriterAudioInput = [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeAudio outputSettings:audioOutputSettings];
+        }
+
         [assetWriter addInput:assetWriterAudioInput];
         assetWriterAudioInput.expectsMediaDataInRealTime = _encodingLiveVideo;
     }


### PR DESCRIPTION
Make AVAssetWriterInput use the new initializer `+ (AVAssetWriterInput *)assetWriterInputWithMediaType:(NSString *)mediaType outputSettings:(NSDictionary *)outputSettings sourceFormatHint:(CMFormatDescriptionRef)sourceFormatHint NS_AVAILABLE(10_8, 6_0);` which includes the ability to hint at the format of media data that will be appended to the new instance of AVAssetWriterInput.

This gives the GPUImageMovieWriter the ability to passthrough audio for more movie file types, for example mp4.
