### PR TITLE
Swipe gesture to go back to list stops capturing, even when gesture is aborted.

### DIFF
--- a/examples/iOS/FilterShowcase/FilterShowcase/ShowcaseFilterViewController.m
+++ b/examples/iOS/FilterShowcase/FilterShowcase/ShowcaseFilterViewController.m
@@ -49,6 +49,14 @@
 	[super viewWillDisappear:animated];
 }
 
+- (void)viewDidAppear:(BOOL)animated
+{
+    [super viewDidAppear:animated];
+    
+    // Note: I needed to start camera capture after the view went on the screen, when a partially transition of navigation view controller stopped capturing via viewWilDisappear.
+    [videoCamera startCameraCapture];
+}
+
 - (void)viewDidUnload
 {
     [super viewDidUnload];


### PR DESCRIPTION
If you swipe right from the presentation view to go back to the list, then viewWillDisappear is called correctly and capturing then is stopped. When the user chooses to abort the gesture, then the view transitions back to the presentation view with a stopped version, never can start it again.

I just added starting of the capture in the viewDidAppear again and everything works properly. Would be great, if you merge this little fix.
