### PR TITLE
Support to write GPUImagePicture into a movie file

### DIFF
--- a/framework/Source/iOS/GPUImagePicture.h
+++ b/framework/Source/iOS/GPUImagePicture.h
@@ -10,6 +10,8 @@
     dispatch_semaphore_t imageUpdateSemaphore;
 }
 
+@property CMTime imageFrameTime;
+
 // Initialization and teardown
 - (id)initWithURL:(NSURL *)url;
 - (id)initWithImage:(UIImage *)newImageSource;

--- a/framework/Source/iOS/GPUImagePicture.m
+++ b/framework/Source/iOS/GPUImagePicture.m
@@ -61,6 +61,7 @@
     }
     
     hasProcessedImage = NO;
+    self.imageFrameTime = kCMTimeIndefinite;
     self.shouldSmoothlyScaleOutput = smoothlyScaleOutput;
     imageUpdateSemaphore = dispatch_semaphore_create(0);
     dispatch_semaphore_signal(imageUpdateSemaphore);
@@ -263,7 +264,7 @@
             [currentTarget setCurrentlyReceivingMonochromeInput:NO];
             [currentTarget setInputSize:pixelSizeOfImage atIndex:textureIndexOfTarget];
             [currentTarget setInputFramebuffer:outputFramebuffer atIndex:textureIndexOfTarget];
-            [currentTarget newFrameReadyAtTime:kCMTimeIndefinite atIndex:textureIndexOfTarget];
+            [currentTarget newFrameReadyAtTime:self.imageFrameTime atIndex:textureIndexOfTarget];
         }
         
         dispatch_semaphore_signal(imageUpdateSemaphore);
@@ -297,7 +298,7 @@
     if (hasProcessedImage)
     {
         [newTarget setInputSize:pixelSizeOfImage atIndex:textureLocation];
-        [newTarget newFrameReadyAtTime:kCMTimeIndefinite atIndex:textureLocation];
+        [newTarget newFrameReadyAtTime:self.imageFrameTime atIndex:textureLocation];
     }
 }
 


### PR DESCRIPTION
Add timeframe support to GPUImagePicture so that it can be written to a movie file using GPUImageMovieWriter.

Example of a self-contained method that zooms in on a image and write to a file:

```
+ (void)zoomInAndWriteToMovie:(UIImage*)image
{
    NSString* moviePath = @"output.mp4";
    NSString* documentPath = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory,NSUserDomainMask, YES) firstObject];
    NSURL* movieURL = [NSURL URLWithString:moviePath relativeToURL: [NSURL fileURLWithPath:documentPath isDirectory:YES]];
    GPUImageMovieWriter *movieWriter = [[GPUImageMovieWriter alloc] initWithMovieURL:movieURL size:CGSizeMake(1280,720)];

    GPUImagePicture *imageSource = [[GPUImagePicture alloc] initWithImage:image];
    GPUImageTransformFilter *transformFilter = [[GPUImageTransformFilter alloc] init];
    [imageSource addTarget:transformFilter];

    [transformFilter addTarget:movieWriter];
    [movieWriter startRecording];

    const int totalFrames = 100;
    const float startZoomRatio = 1.2f;
    const float endZoomRatio = 1.0f;
    for (int i = 0; i < totalFrames; i++) {
        float currentZoomRatio = startZoomRatio + (endZoomRatio - startZoomRatio) * i / (float)totalFrames;
        CGAffineTransform scaleTransform = CGAffineTransformMakeScale(currentZoomRatio, currentZoomRatio);

        transformFilter.affineTransform = scaleTransform;
        imageSource.imageFrameTime = CMTimeMake(i, 30); // 30 FPS

        dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
        [imageSource processImageWithCompletionHandler:^{
            dispatch_semaphore_signal(semaphore);
        }];

        dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
    }
                [[GPUImageContext sharedFramebufferCache] purgeAllUnassignedFramebuffers];
    [transformFilter removeTarget:movieWriter];

    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
    [movieWriter finishRecordingWithCompletionHandler:^{
        dispatch_semaphore_signal(semaphore); // Force to wait for the completion, it might be causing bugs to continue without waiting.
    }];

    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
    [transformFilter removeAllTargets];
    [imageSource removeAllTargets];
}
```
