### PR TITLE
Added -(NSArray *)targets support to GPUImageFilterGroup

### DIFF
--- a/framework/Source/GPUImageFilterGroup.m
+++ b/framework/Source/GPUImageFilterGroup.m
@@ -73,6 +73,11 @@
     [_terminalFilter removeAllTargets];
 }
 
+- (NSArray *)targets;
+{
+    return [_terminalFilter targets];
+}
+
 - (void)setFrameProcessingCompletionBlock:(void (^)(GPUImageOutput *, CMTime))frameProcessingCompletionBlock;
 {
     [_terminalFilter setFrameProcessingCompletionBlock:frameProcessingCompletionBlock];


### PR DESCRIPTION
Targets get added to the terminal filter in GPUImageFilterGroup, so calling "targets" on this class should return the terminal filter's targets array. Currently GPUImageFilterGroup's superclass (GPUImageOutput) responds to this method, which returns an empty array.