### PR TITLE
Implement shouldResizeBlurRadiusWithImageSize feature for blurs.

### DIFF
--- a/framework/Source/GPUImageGaussianBlurFilter.h
+++ b/framework/Source/GPUImageGaussianBlurFilter.h
@@ -18,7 +18,7 @@
  */
 @property (readwrite, nonatomic) CGFloat blurRadiusInPixels;
 
-/** Setting these properties will allow the blur radius to scale with the size of the image
+/** Setting these properties will allow the blur radius to scale with the size of the image. These properties are mutually exclusive; setting either will set the other to 0.
  */
 @property (readwrite, nonatomic) CGFloat blurRadiusAsFractionOfImageWidth;
 @property (readwrite, nonatomic) CGFloat blurRadiusAsFractionOfImageHeight;

--- a/framework/Source/GPUImageGaussianBlurFilter.m
+++ b/framework/Source/GPUImageGaussianBlurFilter.m
@@ -352,9 +352,16 @@
 {
     [super setupFilterForSize:filterFrameSize];
     
-    if (shouldResizeBlurRadiusWithImageSize == YES)
+    if (shouldResizeBlurRadiusWithImageSize)
     {
-        
+        if (self.blurRadiusAsFractionOfImageWidth > 0)
+        {
+            self.blurRadiusInPixels = filterFrameSize.width * self.blurRadiusAsFractionOfImageWidth;
+        }
+        else
+        {
+            self.blurRadiusInPixels = filterFrameSize.height * self.blurRadiusAsFractionOfImageHeight;
+        }
     }
 }
 
@@ -483,6 +490,24 @@
         [self switchToVertexShader:newGaussianBlurVertexShader fragmentShader:newGaussianBlurFragmentShader];
     }
     shouldResizeBlurRadiusWithImageSize = NO;
+}
+
+- (void)setBlurRadiusAsFractionOfImageWidth:(CGFloat)blurRadiusAsFractionOfImageWidth
+{
+    if (blurRadiusAsFractionOfImageWidth < 0)  return;
+
+    shouldResizeBlurRadiusWithImageSize = _blurRadiusAsFractionOfImageWidth != blurRadiusAsFractionOfImageWidth && blurRadiusAsFractionOfImageWidth > 0;
+    _blurRadiusAsFractionOfImageWidth = blurRadiusAsFractionOfImageWidth;
+    _blurRadiusAsFractionOfImageHeight = 0;
+}
+
+- (void)setBlurRadiusAsFractionOfImageHeight:(CGFloat)blurRadiusAsFractionOfImageHeight
+{
+    if (blurRadiusAsFractionOfImageHeight < 0)  return;
+
+    shouldResizeBlurRadiusWithImageSize = _blurRadiusAsFractionOfImageHeight != blurRadiusAsFractionOfImageHeight && blurRadiusAsFractionOfImageHeight > 0;
+    _blurRadiusAsFractionOfImageHeight = blurRadiusAsFractionOfImageHeight;
+    _blurRadiusAsFractionOfImageWidth = 0;
 }
 
 @end


### PR DESCRIPTION
Resolves #1428.

Took the liberty of making blurRadiusAsFractionOfImageWidth/Height be mutually exclusive. Updated the header documentation as such. Not sure if this constrains any derived blur filters.

Perhaps it is worth noting in the header file what typical values are for these properties; i.e. they are on the order of ten-thousandths. Values greater than this will appear to hang a thread!