### PR TITLE
Added focus observer funtionality also methods to set a focus point

### DIFF
--- a/framework/Source/GPUImageVideoCamera.h
+++ b/framework/Source/GPUImageVideoCamera.h
@@ -101,6 +101,12 @@ extern NSString *const kGPUImageYUVVideoRangeConversionForLAFragmentShaderString
 - (void)removeInputsAndOutputs;
 
 /// @name Manage the camera video stream
+- (bool) isAutoFocusSupported;
+- (bool) isAutoExposureSupported;
+
+- (void)setFocus:(CGPoint)p :(CGSize) viewSize;
+
+- (void) setToAutoFocusMode;
 
 /** Start camera capturing
  */

--- a/framework/Source/GPUImageVideoCamera.m
+++ b/framework/Source/GPUImageVideoCamera.m
@@ -390,6 +390,57 @@ NSString *const kGPUImageYUVVideoRangeConversionForLAFragmentShaderString = SHAD
 
 #pragma mark -
 #pragma mark Manage the camera video stream
+- (bool) isAutoFocusSupported
+{
+    return [_inputCamera isFocusPointOfInterestSupported] ;
+}
+
+- (bool) isAutoExposureSupported
+{
+    return [_inputCamera isExposurePointOfInterestSupported];
+}
+- (void) setToAutoFocusMode
+{
+    NSError* error = nil;
+    if ([_inputCamera lockForConfiguration:&error] == NO) {
+        NSLog(@"%s|[ERROR] %@", __PRETTY_FUNCTION__, error);
+    }
+    
+    if ([_inputCamera isFocusPointOfInterestSupported])
+    {
+        _inputCamera.focusPointOfInterest = CGPointMake(.5f, .5f);
+        _inputCamera.focusMode = AVCaptureFocusModeContinuousAutoFocus;
+    }
+    [_inputCamera unlockForConfiguration];
+}
+
+/*!
+ * set focus and exposure point
+ */
+- (void)setFocus:(CGPoint)p : (CGSize) viewSize
+{
+    CGPoint pointOfInterest = CGPointMake(p.y / viewSize.height, 1.0 - p.x / viewSize.width);
+    
+    NSError* error = nil;
+    if ([_inputCamera lockForConfiguration:&error] == NO) {
+        NSLog(@"%s|[ERROR] %@", __PRETTY_FUNCTION__, error);
+    }
+    
+    if ([_inputCamera isFocusPointOfInterestSupported] &&
+        [_inputCamera isFocusModeSupported:AVCaptureFocusModeAutoFocus]) {
+        _inputCamera.focusPointOfInterest = pointOfInterest;
+        _inputCamera.focusMode = AVCaptureFocusModeAutoFocus;
+    }
+    
+    if ([_inputCamera isExposurePointOfInterestSupported] &&
+        [_inputCamera isExposureModeSupported:AVCaptureExposureModeContinuousAutoExposure]){
+        _inputCamera.exposurePointOfInterest = pointOfInterest;
+        _inputCamera.exposureMode = AVCaptureExposureModeContinuousAutoExposure;
+    }
+    
+    [_inputCamera unlockForConfiguration];
+}
+
 
 - (void)startCameraCapture;
 {


### PR DESCRIPTION
An observer can be set like this. This can be used to show a square to
visualize the selected focus point.
- (void)addCameraObservers {
    if ([_stillCamera isAutoFocusSupported] && !_focusObserverAdded) {
        [self addObserver:self
               forKeyPath:@"stillCamera.inputCamera.focusMode"
                  options:NSKeyValueObservingOptionNew
                  context:_AVCamFocusModeObserverContext];

        _focusObserverAdded = YES;
    }
}

Also its possible to let the camera focus things with
 [self.stillCamera setFocus:tapPoint : self.streamPreviewView.frame.size];