### PR TITLE
Allow for luminance upload

### DIFF
--- a/framework/Source/GPUImageRawDataInput.m
+++ b/framework/Source/GPUImageRawDataInput.m
@@ -72,7 +72,7 @@
     outputFramebuffer = [[GPUImageContext sharedFramebufferCache] fetchFramebufferForSize:uploadedImageSize textureOptions:self.outputTextureOptions onlyTexture:YES];
     
     glBindTexture(GL_TEXTURE_2D, [outputFramebuffer texture]);
-    glTexImage2D(GL_TEXTURE_2D, 0, _pixelFormat==GPUPixelFormatRGB ? GL_RGB : GL_RGBA, (int)uploadedImageSize.width, (int)uploadedImageSize.height, 0, (GLint)_pixelFormat, (GLenum)_pixelType, bytesToUpload);
+    glTexImage2D(GL_TEXTURE_2D, 0, _pixelFormat, (int)uploadedImageSize.width, (int)uploadedImageSize.height, 0, (GLint)_pixelFormat, (GLenum)_pixelType, bytesToUpload);
 }
 
 - (void)updateDataFromBytes:(GLubyte *)bytesToUpload size:(CGSize)imageSize;


### PR DESCRIPTION
It was hard coded to two types and since pixelFormat directly maps to GL types, it needs to allow for all types. I am using luminance successfully with this approach. I am basically passing in a binary mask and so RGB would be overkill

These types must all have support:
GPUPixelFormatBGRA = GL_BGRA,
GPUPixelFormatRGBA = GL_RGBA,
GPUPixelFormatRGB = GL_RGB,
GPUPixelFormatLuminance = GL_LUMINANCE