### PR TITLE
bulge distortion fix

### DIFF
--- a/framework/Source/GPUImageBulgeDistortionFilter.m
+++ b/framework/Source/GPUImageBulgeDistortionFilter.m
@@ -14,7 +14,7 @@ NSString *const kGPUImageBulgeDistortionFragmentShaderString = SHADER_STRING
 
  void main()
  {
-    highp vec2 textureCoordinateToUse = vec2(textureCoordinate.x, (textureCoordinate.y * aspectRatio + 0.5 - 0.5 * aspectRatio));
+    highp vec2 textureCoordinateToUse = vec2(textureCoordinate.x, ((textureCoordinate.y - center.y) * aspectRatio) + center.y);
     highp float dist = distance(center, textureCoordinateToUse);
     textureCoordinateToUse = textureCoordinate;
     
@@ -45,7 +45,7 @@ NSString *const kGPUImageBulgeDistortionFragmentShaderString = SHADER_STRING
  
  void main()
  {
-    vec2 textureCoordinateToUse = vec2(textureCoordinate.x, (textureCoordinate.y * aspectRatio + 0.5 - 0.5 * aspectRatio));
+    vec2 textureCoordinateToUse = vec2(textureCoordinate.x, ((textureCoordinate.y - center.y) * aspectRatio) + center.y);
     float dist = distance(center, textureCoordinateToUse);
     textureCoordinateToUse = textureCoordinate;
     


### PR DESCRIPTION
fix a bug in bulge distortion fragment shader which causes the distortion area to be misplaced when the distortion center y is not 0.5

Distortion area before fix __center = (x:0.5, y:0.1), radius = 0.1__
![beforefix](https://cloud.githubusercontent.com/assets/1234944/6056673/40b655a8-ad4f-11e4-82e1-960fd03e25ed.png)

Distortion area after fix __center = (x:0.5, y:0.1), radius = 0.1__
![afterfix](https://cloud.githubusercontent.com/assets/1234944/6056677/4cc81e80-ad4f-11e4-9315-f4b8131e57c7.png)
