### PR TITLE
Workaround for Issue #1695

### DIFF
--- a/framework/Source/GPUImageFramebuffer.m
+++ b/framework/Source/GPUImageFramebuffer.m
@@ -4,6 +4,7 @@
 @interface GPUImageFramebuffer()
 {
     GLuint framebuffer;
+    GLuint __padding[7];
 #if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
     CVPixelBufferRef renderTarget;
     CVOpenGLESTextureRef renderTexture;


### PR DESCRIPTION
An app I've been working has been crashing as described in issue #1695, with a SIGTRAP on line 333 or SIGSEGV on line 329 of GPUImageFramebuffer.m in the newCGImageFromFramebufferContents method (based on version 0.1.5 source), but I was never able to reproduce the issue while debugging. I saw JensDee's comment about the value of renderTarget being either 0 or 5, and was able to reproduce the SIGTRAP by manually setting renderTarget to 0, and the SIGSEGV by setting renderTarget to 5. That got me thinking in terms of stray memory writes, which in turn got me to realize that I was only getting crash reports from 32-bit versions of the app, and that in 64-bit builds there should be four bytes of padding between the framebuffer (a GLuint) and renderTarget (a pointer) fields to maintain their natural alignments.

As a longshot, I added padding between the two fields (with a bit extra just because) to ensure the fields were separated even in 32-bit builds, and that seems to have cleared up the issue for me.

Obviously this isn't a proper fix since it's just patching over the symptom, but hopefully this will get someone more familiar with the code base than I am looking in the likely spots where a pointer might be getting typecast to point to the wrong size of integer, or something along those lines.
