### PR TITLE
setIntensity not defined on GPUImageColorInvertFilter and was causing crash.

### DIFF
--- a/examples/iOS/SimpleVideoFilter/SimpleVideoFilter/SimpleVideoFilterViewController.m
+++ b/examples/iOS/SimpleVideoFilter/SimpleVideoFilter/SimpleVideoFilterViewController.m
@@ -30,8 +30,8 @@
     videoCamera.horizontallyMirrorFrontFacingCamera = NO;
     videoCamera.horizontallyMirrorRearFacingCamera = NO;
 
-//    filter = [[GPUImageSepiaFilter alloc] init];
-    
+    filter = [[GPUImageSepiaFilter alloc] init];
+  
 //    filter = [[GPUImageTiltShiftFilter alloc] init];
 //    [(GPUImageTiltShiftFilter *)filter setTopFocusLevel:0.65];
 //    [(GPUImageTiltShiftFilter *)filter setBottomFocusLevel:0.85];
@@ -39,7 +39,7 @@
 //    [(GPUImageTiltShiftFilter *)filter setFocusFallOffRate:0.2];
     
 //    filter = [[GPUImageSketchFilter alloc] init];
-    filter = [[GPUImageColorInvertFilter alloc] init];
+//    filter = [[GPUImageColorInvertFilter alloc] init];
 //    filter = [[GPUImageSmoothToonFilter alloc] init];
 //    GPUImageRotationFilter *rotationFilter = [[GPUImageRotationFilter alloc] initWithRotation:kGPUImageRotateRightFlipVertical];
     


### PR DESCRIPTION
`setIntensity` not defined on `GPUImageColorInvertFilter` and was causing crash. Original example used `GPUImageSepiaFilter` in `updateSliderValue`, so I'm guessing that was the intention.