### PR TITLE
Fix for recording input from three inputs where timestamps don't match. ...

### DIFF
--- a/framework/Source/GPUImageThreeInputFilter.m
+++ b/framework/Source/GPUImageThreeInputFilter.m
@@ -317,7 +317,8 @@ NSString *const kGPUImageThreeInputTextureVertexShaderString = SHADER_STRING
         
         [self renderToTextureWithVertices:imageVertices textureCoordinates:[[self class] textureCoordinatesForRotation:inputRotation]];
         
-        [self informTargetsAboutNewFrameAtTime:frameTime];
+        CMTime passOnFrameTime = (!CMTIME_IS_INDEFINITE(firstFrameTime)) ? firstFrameTime : (!CMTIME_IS_INDEFINITE(secondFrameTime)) ? secondFrameTime : thirdFrameTime;
+        [self informTargetsAboutNewFrameAtTime:passOnFrameTime];
 
         hasReceivedFirstFrame = NO;
         hasReceivedSecondFrame = NO;


### PR DESCRIPTION
...See commits e698ccb64637 and 68d930a9abdf for similar fix in GPUImageTwoInputFilter.m.