### PR TITLE
GPUImageFilterPipeline

### DIFF
--- a/framework/Source/GPUImageFilterPipeline.h
+++ b/framework/Source/GPUImageFilterPipeline.h
@@ -8,8 +8,8 @@
 
 @property (strong) NSMutableArray *filters;
 
-@property (strong) GPUImageOutput *input;
-@property (strong) id <GPUImageInput> output;
+@property (nonatomic, strong) GPUImageOutput *input;
+@property (nonatomic, strong) id <GPUImageInput> output;
 
 - (id) initWithOrderedFilters:(NSArray*) filters input:(GPUImageOutput*)input output:(id <GPUImageInput>)output;
 - (id) initWithConfiguration:(NSDictionary*) configuration input:(GPUImageOutput*)input output:(id <GPUImageInput>)output;

--- a/framework/Source/GPUImageFilterPipeline.m
+++ b/framework/Source/GPUImageFilterPipeline.m
@@ -184,6 +184,16 @@
     [self _refreshFilters];
 }
 
+- (void)setInput:(GPUImageOutput *)input {
+  _input = input;
+  [self _refreshFilters];
+}
+
+- (void)setOutput:(id<GPUImageInput>)output {
+  _output = output;
+  [self _refreshFilters];
+}
+
 - (void)_refreshFilters {
     
     id prevFilter = self.input;

--- a/framework/Source/GPUImageFilterPipeline.m
+++ b/framework/Source/GPUImageFilterPipeline.m
@@ -14,6 +14,14 @@
 
 #pragma mark Config file init
 
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    self.filters = [NSMutableArray array];
+  }
+  return self;
+}
+
 - (id)initWithConfiguration:(NSDictionary *)configuration input:(GPUImageOutput *)input output:(id <GPUImageInput>)output {
     self = [super init];
     if (self) {

--- a/framework/Source/GPUImageOutput.h
+++ b/framework/Source/GPUImageOutput.h
@@ -58,6 +58,7 @@ void reportAvailableMemoryForGPUImage(NSString *tag);
 @property(nonatomic, copy) void(^frameProcessingCompletionBlock)(GPUImageOutput*, CMTime);
 @property(nonatomic) BOOL enabled;
 @property(readwrite, nonatomic) GPUTextureOptions outputTextureOptions;
+@property(readwrite) BOOL shouldMatchOrientationToDevice;
 
 /// @name Managing targets
 - (void)setInputFramebufferForTarget:(id<GPUImageInput>)target atIndex:(NSInteger)inputTextureIndex;

--- a/framework/Source/GPUImageOutput.m
+++ b/framework/Source/GPUImageOutput.m
@@ -150,6 +150,8 @@ void reportAvailableMemoryForGPUImage(NSString *tag)
     _outputTextureOptions.internalFormat = GL_RGBA;
     _outputTextureOptions.format = GL_BGRA;
     _outputTextureOptions.type = GL_UNSIGNED_BYTE;
+  
+    _shouldMatchOrientationToDevice = YES;
 
     return self;
 }
@@ -318,27 +320,30 @@ void reportAvailableMemoryForGPUImage(NSString *tag)
 
 - (UIImage *)imageFromCurrentFramebuffer;
 {
-	UIDeviceOrientation deviceOrientation = [[UIDevice currentDevice] orientation];
-    UIImageOrientation imageOrientation = UIImageOrientationLeft;
-	switch (deviceOrientation)
-    {
-		case UIDeviceOrientationPortrait:
-			imageOrientation = UIImageOrientationUp;
-			break;
-		case UIDeviceOrientationPortraitUpsideDown:
-			imageOrientation = UIImageOrientationDown;
-			break;
-		case UIDeviceOrientationLandscapeLeft:
-			imageOrientation = UIImageOrientationLeft;
-			break;
-		case UIDeviceOrientationLandscapeRight:
-			imageOrientation = UIImageOrientationRight;
-			break;
-		default:
-			imageOrientation = UIImageOrientationUp;
-			break;
-	}
+    UIImageOrientation imageOrientation = UIImageOrientationUp;
     
+    if (_shouldMatchOrientationToDevice) {
+        UIDeviceOrientation deviceOrientation = [[UIDevice currentDevice] orientation];
+        switch (deviceOrientation)
+        {
+          case UIDeviceOrientationPortrait:
+            imageOrientation = UIImageOrientationUp;
+            break;
+          case UIDeviceOrientationPortraitUpsideDown:
+            imageOrientation = UIImageOrientationDown;
+            break;
+          case UIDeviceOrientationLandscapeLeft:
+            imageOrientation = UIImageOrientationLeft;
+            break;
+          case UIDeviceOrientationLandscapeRight:
+            imageOrientation = UIImageOrientationRight;
+            break;
+          default:
+            imageOrientation = UIImageOrientationUp;
+            break;
+        }
+    }
+  
     return [self imageFromCurrentFramebufferWithOrientation:imageOrientation];
 }
 

--- a/framework/Source/GPUImageStillCamera.m
+++ b/framework/Source/GPUImageStillCamera.m
@@ -279,8 +279,12 @@ void GPUImageCreateResizedSampleBuffer(CVPixelBufferRef cameraFrame, CGSize fina
         block([NSError errorWithDomain:AVFoundationErrorDomain code:AVErrorMaximumStillImageCaptureRequestsExceeded userInfo:nil]);
         return;
     }
+    if(![photoOutput connections].firstObject){
+        block([NSError errorWithDomain:AVFoundationErrorDomain code:AVErrorSessionNotRunning userInfo:nil]);
+        return;
+    }
 
-    [photoOutput captureStillImageAsynchronouslyFromConnection:[[photoOutput connections] objectAtIndex:0] completionHandler:^(CMSampleBufferRef imageSampleBuffer, NSError *error) {
+    [photoOutput captureStillImageAsynchronouslyFromConnection:[photoOutput connections].firstObject completionHandler:^(CMSampleBufferRef imageSampleBuffer, NSError *error) {
         if(imageSampleBuffer == NULL){
             block(error);
             return;


### PR DESCRIPTION
When packaging up multiple filters into a single pipeline, I found that I was unable to create a pipeline from scratch. The failure was that the `filters` array had not been initialized, so adding new filters would just toss them at a `nil` object.

Once the `filters` array was initialized, I additionally found that I needed to set the `input` and `output` before adding the final filter or else the `filters` would not be properly attached to my `input` and `output`. Making these properties `nonatomic` and calling `_refreshFilters` in the setters has easily solved this issue.

***Side note:***
This functionality was obviously not working as I had expected, but I'm not sure that I even agree with the final result here. I think that I would prefer to have the pipeline behave like a regular filter (as a `GPUImageOutput<GPUImageInput>`). The work to make this migration happen is much more involved than this simple patch, and I have not investigated to see if there were any specific architectural decisions made that lead the pipeline to where it is today.