### PR TITLE
Mutable GPUImagePicture

### DIFF
--- a/framework/Source/iOS/GPUImagePicture.h
+++ b/framework/Source/iOS/GPUImagePicture.h
@@ -17,6 +17,9 @@
 - (id)initWithImage:(UIImage *)newImageSource smoothlyScaleOutput:(BOOL)smoothlyScaleOutput;
 - (id)initWithCGImage:(CGImageRef)newImageSource smoothlyScaleOutput:(BOOL)smoothlyScaleOutput;
 
+// Update the image
+- (void)updateCGImage:(CGImageRef)newImageSource smoothlyScaleOutput:(BOOL)smoothlyScaleOutput;
+
 // Image rendering
 - (void)processImage;
 - (CGSize)outputImageSize;


### PR DESCRIPTION
I thought I'd submit this to you for review. I've been trying to use GPUImageOverlayBlendFilter to render dynamic text onto my video.

    When updating the GPUImagePicture to render I would often get an assertion of
    NSAssert(framebufferReferenceCount > 0, @"Tried to overrelease a framebuffer, did you forget to call -useNextFrameForImageCapture before using -imageFromCurrentFramebuffer?");

    Looking online and in your github repository issues I came across some of your comments (Brad Larson) where you said that GPUImagePicture was a tricky case and you weren't quite sure how to solve it.

    This may not be the best solution possible but it's working in my case. I've added a new method to update the source image. This way a client can use one instance of GPUImagePicture and update the contents instead of creating an new one.