### PR TITLE
Option to remove alpha premultiplication from GPUImagePicture

### DIFF
--- a/framework/Source/iOS/GPUImagePicture.h
+++ b/framework/Source/iOS/GPUImagePicture.h
@@ -16,6 +16,10 @@
 - (id)initWithCGImage:(CGImageRef)newImageSource;
 - (id)initWithImage:(UIImage *)newImageSource smoothlyScaleOutput:(BOOL)smoothlyScaleOutput;
 - (id)initWithCGImage:(CGImageRef)newImageSource smoothlyScaleOutput:(BOOL)smoothlyScaleOutput;
+- (id)initWithImage:(UIImage *)newImageSource removePremultiplication:(BOOL)removePremultiplication;
+- (id)initWithCGImage:(CGImageRef)newImageSource removePremultiplication:(BOOL)removePremultiplication;
+- (id)initWithImage:(UIImage *)newImageSource smoothlyScaleOutput:(BOOL)smoothlyScaleOutput removePremultiplication:(BOOL)removePremultiplication;
+- (id)initWithCGImage:(CGImageRef)newImageSource smoothlyScaleOutput:(BOOL)smoothlyScaleOutput removePremultiplication:(BOOL)removePremultiplication;
 
 // Image rendering
 - (void)processImage;


### PR DESCRIPTION
Added new init methods to GPUImagePicture to correct RGB values when source contains premultiplied alpha. 

I created a simple `GPUImageFilter` which simply copies the source to demonstrate the difference between a corrected and uncorrected image. The first image is the original, the second uncorrected, and the third corrected by removing the premultiplied alpha.

![premult](https://cloud.githubusercontent.com/assets/152576/8253591/fe99b306-1656-11e5-8c57-eea6d4a3d3f3.png)

This is a brute force CPU conversion at the moment but perhaps a filter could be created for this purpose as well?