### PR TITLE
Movie writer error handling for -startRecording and -finishRecording via blocks

### DIFF
--- a/framework/GPUImage.xcodeproj/project.pbxproj
+++ b/framework/GPUImage.xcodeproj/project.pbxproj
@@ -1904,7 +1904,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastTestingUpgradeCheck = 0510;
-				LastUpgradeCheck = 0600;
+				LastUpgradeCheck = 0630;
 				ORGANIZATIONNAME = "Brad Larson";
 				TargetAttributes = {
 					BCE209E41943F20C002FEED8 = {
@@ -2399,6 +2399,7 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -2438,6 +2439,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/framework/GPUImage.xcodeproj/project.pbxproj
+++ b/framework/GPUImage.xcodeproj/project.pbxproj
@@ -2344,6 +2344,7 @@
 				MODULEMAP_FILE = Source/iOS/Framework/module.modulemap;
 				PRODUCT_MODULE_NAME = GPUImage;
 				PRODUCT_NAME = GPUImage;
+				RUN_CLANG_STATIC_ANALYZER = NO;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
@@ -2375,6 +2376,7 @@
 				MODULEMAP_FILE = Source/iOS/Framework/module.modulemap;
 				PRODUCT_MODULE_NAME = GPUImage;
 				PRODUCT_NAME = GPUImage;
+				RUN_CLANG_STATIC_ANALYZER = NO;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";

--- a/framework/GPUImage.xcodeproj/xcshareddata/xcschemes/Documentation.xcscheme
+++ b/framework/GPUImage.xcodeproj/xcshareddata/xcschemes/Documentation.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/framework/GPUImage.xcodeproj/xcshareddata/xcschemes/GPUImage.xcscheme
+++ b/framework/GPUImage.xcodeproj/xcshareddata/xcschemes/GPUImage.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/framework/GPUImage.xcodeproj/xcshareddata/xcschemes/GPUImageFramework.xcscheme
+++ b/framework/GPUImage.xcodeproj/xcshareddata/xcschemes/GPUImageFramework.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0630"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/framework/Source/iOS/GPUImageMovieWriter.h
+++ b/framework/Source/iOS/GPUImageMovieWriter.h
@@ -58,9 +58,12 @@ extern NSString *const kGPUImageColorSwizzlingFragmentShaderString;
 // Movie recording
 - (void)startRecording;
 - (void)startRecordingInOrientation:(CGAffineTransform)orientationTransform;
+- (void)startRecordindWithCompletionHandler:(void(^)(BOOL didStart, NSError *error))completionHandler;
+
 - (void)finishRecording;
-- (void)finishRecordingWithCompletionHandler:(void (^)(void))handler;
+- (void)finishRecordingWithCompletionHandler:(void (^)(BOOL completed, NSError *error))handler;
 - (void)cancelRecording;
+
 - (void)processAudioBuffer:(CMSampleBufferRef)audioBuffer;
 - (void)enableSynchronizationCallbacks;
 


### PR DESCRIPTION
This method catches errors from the asset writer as well.