### PR TITLE
GPUImageAddBlendFilter: Added an alpha mixture property.

### DIFF
--- a/framework/Source/GPUImageAddBlendFilter.h
+++ b/framework/Source/GPUImageAddBlendFilter.h
@@ -1,5 +1,12 @@
 #import "GPUImageTwoInputFilter.h"
 
 @interface GPUImageAddBlendFilter : GPUImageTwoInputFilter
+{
+    GLint mixUniform;
+}
+
+// Mix ranges from 0.0 (only image 1) to 1.0 (only image 2), with 1.0 as the normal level
+@property(readwrite, nonatomic) CGFloat mix;
 
 @end
+

--- a/framework/Source/GPUImageAddBlendFilter.m
+++ b/framework/Source/GPUImageAddBlendFilter.m
@@ -9,10 +9,13 @@ NSString *const kGPUImageAddBlendFragmentShaderString = SHADER_STRING
  uniform sampler2D inputImageTexture;
  uniform sampler2D inputImageTexture2;
  
+  uniform lowp float mixturePercent;
+ 
  void main()
  {
 	 lowp vec4 base = texture2D(inputImageTexture, textureCoordinate);
 	 lowp vec4 overlay = texture2D(inputImageTexture2, textureCoordinate2);
+     overlay.a *= mixturePercent;
 	 
    mediump float r;
    if (overlay.r * base.a + base.r * overlay.a >= overlay.a * base.a) {
@@ -20,7 +23,7 @@ NSString *const kGPUImageAddBlendFragmentShaderString = SHADER_STRING
    } else {
      r = overlay.r + base.r;
    }
-
+     
    mediump float g;
    if (overlay.g * base.a + base.g * overlay.a >= overlay.a * base.a) {
      g = overlay.a * base.a + overlay.g * (1.0 - base.a) + base.g * (1.0 - overlay.a);
@@ -49,10 +52,13 @@ NSString *const kGPUImageAddBlendFragmentShaderString = SHADER_STRING
  uniform sampler2D inputImageTexture;
  uniform sampler2D inputImageTexture2;
  
+  uniform float mixturePercent;
+ 
  void main()
  {
 	 vec4 base = texture2D(inputImageTexture, textureCoordinate);
 	 vec4 overlay = texture2D(inputImageTexture2, textureCoordinate2);
+     overlay.a *= mixturePercent;
 	 
      float r;
      if (overlay.r * base.a + base.r * overlay.a >= overlay.a * base.a) {
@@ -86,6 +92,8 @@ NSString *const kGPUImageAddBlendFragmentShaderString = SHADER_STRING
 
 @implementation GPUImageAddBlendFilter
 
+@synthesize mix = _mix;
+
 - (id)init;
 {
     if (!(self = [super initWithFragmentShaderFromString:kGPUImageAddBlendFragmentShaderString]))
@@ -93,8 +101,22 @@ NSString *const kGPUImageAddBlendFragmentShaderString = SHADER_STRING
 		return nil;
     }
     
+    mixUniform = [filterProgram uniformIndex:@"mixturePercent"];
+    self.mix = 1.0;
+    
     return self;
 }
 
+#pragma mark -
+#pragma mark Accessors
+
+- (void)setMix:(CGFloat)newValue;
+{
+    _mix = newValue;
+    
+    [self setFloat:_mix forUniform:mixUniform program:filterProgram];
+}
+
 @end
+
 


### PR DESCRIPTION
I've added a "mix" property to GPUImageAddBlendFilter.  The default is 1, and it multiplies the alpha channel of the overlay, allowing the add blend to be continually "mixed."  There may be a better way to achieve this effect which I haven't yet hit upon--but, in case there isn't, I thought I'd submit it to see whether the community would also like this functionality.