### PR TITLE
Crash in GPUImageMovie

### DIFF
--- a/framework/Source/GPUImageMovie.m
+++ b/framework/Source/GPUImageMovie.m
@@ -134,6 +134,8 @@
 
 - (void)dealloc
 {
+    [playerItemOutput setDelegate:nil queue:nil];
+    
     // Moved into endProcessing
     //if (self.playerItem && (displayLink != nil))
     //{


### PR DESCRIPTION
There is an issue in GPUImageMovie - when instance adds itself as AVPlayerItemVideoOutput delegate: [playerItemOutput setDelegate:self queue:videoProcessingQueue], playerItemOutput doesn't release its delegate when GPUImageMovie instance is deallocating. Later, this results in a method call from the deallocated object (outputSequenceWasFlushed:) and you get the crash. This was found with help of NSZombie detector and I fixed it by adding this in GPUImageMovie dealloc method: [playerItemOutput setDelegate:nil queue:nil];

```swift
{
      .......
      currentFilter.removeAllTargets()
      movieFile?.removeAllTargets()
      movieFile?.endProcessing()

      ........

      movieFile = GPUImageMovie(playerItem: videoPlayerView.player.currentItem)
      currentFilter.applyFromOutput(movieFile, toInput: gpuPlayerView)
      movieFile.startProcessing()
}
```