### PR TITLE
Fix Blank Frames at beginning of videos captured through camera with audioEncodingTarget

### DIFF
--- a/framework/Source/iOS/GPUImageMovieWriter.m
+++ b/framework/Source/iOS/GPUImageMovieWriter.m
@@ -373,18 +373,6 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
         CFRetain(audioBuffer);
 
         CMTime currentSampleTime = CMSampleBufferGetOutputPresentationTimeStamp(audioBuffer);
-        
-        if (CMTIME_IS_INVALID(startTime))
-        {
-            runSynchronouslyOnContextQueue(_movieWriterContext, ^{
-                if ((audioInputReadyCallback == NULL) && (assetWriter.status != AVAssetWriterStatusWriting))
-                {
-                    [assetWriter startWriting];
-                }
-                [assetWriter startSessionAtSourceTime:currentSampleTime];
-                startTime = currentSampleTime;
-            });
-        }
 
         if (!assetWriterAudioInput.readyForMoreMediaData && _encodingLiveVideo)
         {


### PR DESCRIPTION
Remove startTime code from processAudioBuffer, which is a duplicate of the code in newFrameReadyAtTime. The copy of the code in processAudioBuffer causes a race condition that results in the blank frames at the beginning of most videos captured from the camera with audio.