### PR TITLE
Added ability to override default YUV to RGB conversion matrices

### DIFF
--- a/framework/Source/GPUImageVideoCamera.h
+++ b/framework/Source/GPUImageVideoCamera.h
@@ -4,12 +4,17 @@
 #import "GPUImageContext.h"
 #import "GPUImageOutput.h"
 
-extern const GLfloat kColorConversion601[];
-extern const GLfloat kColorConversion601FullRange[];
-extern const GLfloat kColorConversion709[];
+extern GLfloat *kColorConversion601;
+extern GLfloat *kColorConversion601FullRange;
+extern GLfloat *kColorConversion709;
 extern NSString *const kGPUImageYUVVideoRangeConversionForRGFragmentShaderString;
 extern NSString *const kGPUImageYUVFullRangeConversionForLAFragmentShaderString;
 extern NSString *const kGPUImageYUVVideoRangeConversionForLAFragmentShaderString;
+
+//Optionally override the YUV to RGB matrices
+void setColorConversion601( GLfloat conversionMatrix[9] );
+void setColorConversion601FullRange( GLfloat conversionMatrix[9] );
+void setColorConversion709( GLfloat conversionMatrix[9] );
 
 
 //Delegate Protocal for Face Detection.

--- a/framework/Source/GPUImageVideoCamera.m
+++ b/framework/Source/GPUImageVideoCamera.m
@@ -5,25 +5,47 @@
 // Color Conversion Constants (YUV to RGB) including adjustment from 16-235/16-240 (video range)
 
 // BT.601, which is the standard for SDTV.
-const GLfloat kColorConversion601[] = {
+GLfloat kColorConversion601Default[] = {
     1.164,  1.164, 1.164,
     0.0, -0.392, 2.017,
     1.596, -0.813,   0.0,
 };
 
+// BT.601 full range (ref: http://www.equasys.de/colorconversion.html)
+GLfloat kColorConversion601FullRangeDefault[] = {
+    1.0,    1.0,    1.0,
+    0.0,    -0.343, 1.765,
+    1.4,    -0.711, 0.0,
+};
+
 // BT.709, which is the standard for HDTV.
-const GLfloat kColorConversion709[] = {
+GLfloat kColorConversion709Default[] = {
     1.164,  1.164, 1.164,
     0.0, -0.213, 2.112,
     1.793, -0.533,   0.0,
 };
 
-// BT.601 full range (ref: http://www.equasys.de/colorconversion.html)
-const GLfloat kColorConversion601FullRange[] = {
-    1.0,    1.0,    1.0,
-    0.0,    -0.343, 1.765,
-    1.4,    -0.711, 0.0,
-};
+
+GLfloat *kColorConversion601 = kColorConversion601Default;
+GLfloat *kColorConversion601FullRange = kColorConversion601FullRangeDefault;
+GLfloat *kColorConversion709 = kColorConversion709Default;
+
+void setColorConversion601( GLfloat conversionMatrix[9] )
+{
+    kColorConversion601 = conversionMatrix;
+}
+
+void setColorConversion601FullRange( GLfloat conversionMatrix[9] )
+{
+    kColorConversion601FullRange = conversionMatrix;
+}
+
+void setColorConversion709( GLfloat conversionMatrix[9] )
+{
+    kColorConversion709 = conversionMatrix;
+}
+
+
 
 NSString *const kGPUImageYUVVideoRangeConversionForRGFragmentShaderString = SHADER_STRING
 (


### PR DESCRIPTION
Added functions so client code could provide their own YUV to RGB conversion matrices in GPUImageVideoCamera.h/m.  Based on the file history and issue threads on the topic it appeared that there wasn't consensus about the proper values for these matrices.  Formerly they were constants and not easily customized by client code.  In our own project we had run into a problem where the default values in the framework produce blown-out highlights when playing back video.  We found values that worked better for us but felt a more flexible solution like this would allow everyone to customize as they see fit without affecting all users of the library.