### PR TITLE
Fix GPUImageMovieWriter isPaused

### DIFF
--- a/framework/Source/GPUImageMovie.m
+++ b/framework/Source/GPUImageMovie.m
@@ -134,6 +134,8 @@
 
 - (void)dealloc
 {
+    [playerItemOutput setDelegate:nil queue:nil];
+    
     // Moved into endProcessing
     //if (self.playerItem && (displayLink != nil))
     //{

--- a/framework/Source/GPUImageVideoCamera.h
+++ b/framework/Source/GPUImageVideoCamera.h
@@ -44,6 +44,9 @@ extern NSString *const kGPUImageYUVVideoRangeConversionForLAFragmentShaderString
     __unsafe_unretained id<GPUImageVideoCameraDelegate> _delegate;
 }
 
+/// Whether or not the underlying AVCaptureSession is running
+@property(readonly, nonatomic) BOOL isRunning;
+
 /// The AVCaptureSession used to capture from the camera
 @property(readonly, retain, nonatomic) AVCaptureSession *captureSession;
 

--- a/framework/Source/GPUImageVideoCamera.m
+++ b/framework/Source/GPUImageVideoCamera.m
@@ -402,6 +402,11 @@ NSString *const kGPUImageYUVVideoRangeConversionForLAFragmentShaderString = SHAD
 #pragma mark -
 #pragma mark Manage the camera video stream
 
+- (BOOL)isRunning;
+{
+    return [_captureSession isRunning];
+}
+
 - (void)startCameraCapture;
 {
     if (![_captureSession isRunning])

--- a/framework/Source/iOS/GPUImageMovieWriter.m
+++ b/framework/Source/iOS/GPUImageMovieWriter.m
@@ -27,8 +27,10 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
 
     GPUImageFramebuffer *firstInputFramebuffer;
     
+    BOOL discont;
     CMTime startTime, previousFrameTime, previousAudioTime;
-
+    CMTime offsetTime;
+    
     dispatch_queue_t audioQueue, videoQueue;
     BOOL audioEncodingIsFinished, videoEncodingIsFinished;
 
@@ -85,6 +87,7 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
     videoEncodingIsFinished = NO;
     audioEncodingIsFinished = NO;
 
+    discont = NO;
     videoSize = newSize;
     movieURL = newMovieURL;
     fileType = newFileType;
@@ -362,7 +365,7 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
 
 - (void)processAudioBuffer:(CMSampleBufferRef)audioBuffer;
 {
-    if (!isRecording)
+    if (!isRecording || _paused)
     {
         return;
     }
@@ -396,6 +399,34 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
             CFRelease(audioBuffer);
             return;
         }
+        
+        if (discont) {
+            discont = NO;
+            
+            CMTime current;
+            if (offsetTime.value > 0) {
+                current = CMTimeSubtract(currentSampleTime, offsetTime);
+            } else {
+                current = currentSampleTime;
+            }
+            
+            CMTime offset = CMTimeSubtract(current, previousAudioTime);
+            
+            if (offsetTime.value == 0) {
+                offsetTime = offset;
+            } else {
+                offsetTime = CMTimeAdd(offsetTime, offset);
+            }
+        }
+        
+        if (offsetTime.value > 0) {
+            CFRelease(audioBuffer);
+            audioBuffer = [self adjustTime:audioBuffer by:offsetTime];
+            CFRetain(audioBuffer);
+        }
+        
+        // record most recent time so we know the length of the pause
+        currentSampleTime = CMSampleBufferGetPresentationTimeStamp(audioBuffer);
 
         previousAudioTime = currentSampleTime;
         
@@ -666,12 +697,35 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
 
 - (void)newFrameReadyAtTime:(CMTime)frameTime atIndex:(NSInteger)textureIndex;
 {
-    if (!isRecording)
+    if (!isRecording || _paused)
     {
         [firstInputFramebuffer unlock];
         return;
     }
 
+    if (discont) {
+        discont = NO;
+        CMTime current;
+        
+        if (offsetTime.value > 0) {
+            current = CMTimeSubtract(frameTime, offsetTime);
+        } else {
+            current = frameTime;
+        }
+        
+        CMTime offset  = CMTimeSubtract(current, previousFrameTime);
+        
+        if (offsetTime.value == 0) {
+            offsetTime = offset;
+        } else {
+            offsetTime = CMTimeAdd(offsetTime, offset);
+        }
+    }
+    
+    if (offsetTime.value > 0) {
+        frameTime = CMTimeSubtract(frameTime, offsetTime);
+    }
+    
     // Drop frames forced by images and other things with no time constants
     // Also, if two consecutive times with the same value are added to the movie, it aborts recording, so I bail on that case
     if ( (CMTIME_IS_INVALID(frameTime)) || (CMTIME_COMPARE_INLINE(frameTime, ==, previousFrameTime)) || (CMTIME_IS_INDEFINITE(frameTime)) ) 
@@ -929,6 +983,34 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
 
 - (AVAssetWriter*)assetWriter {
     return assetWriter;
+}
+
+- (void)setPaused:(BOOL)newValue {
+    if (_paused != newValue) {
+        _paused = newValue;
+        
+        if (_paused) {
+            discont = YES;
+        }
+    }
+}
+
+- (CMSampleBufferRef)adjustTime:(CMSampleBufferRef) sample by:(CMTime) offset {
+    CMItemCount count;
+    CMSampleBufferGetSampleTimingInfoArray(sample, 0, nil, &count);
+    CMSampleTimingInfo* pInfo = malloc(sizeof(CMSampleTimingInfo) * count);
+    CMSampleBufferGetSampleTimingInfoArray(sample, count, pInfo, &count);
+    
+    for (CMItemCount i = 0; i < count; i++) {
+        pInfo[i].decodeTimeStamp = CMTimeSubtract(pInfo[i].decodeTimeStamp, offset);
+        pInfo[i].presentationTimeStamp = CMTimeSubtract(pInfo[i].presentationTimeStamp, offset);
+    }
+    
+    CMSampleBufferRef sout;
+    CMSampleBufferCreateCopyWithNewTiming(nil, sample, count, pInfo, &sout);
+    free(pInfo);
+    
+    return sout;
 }
 
 @end

--- a/framework/Source/iOS/GPUImageView.m
+++ b/framework/Source/iOS/GPUImageView.m
@@ -141,6 +141,8 @@
             [self createDisplayFramebuffer];
             [self recalculateViewGeometry];
         });
+    } else if (!CGSizeEqualToSize(self.bounds.size, CGSizeZero)) {
+        [self recalculateViewGeometry];
     }
 }
 

--- a/framework/Source/iOS/GPUImageView.m
+++ b/framework/Source/iOS/GPUImageView.m
@@ -139,7 +139,6 @@
         runSynchronouslyOnVideoProcessingQueue(^{
             [self destroyDisplayFramebuffer];
             [self createDisplayFramebuffer];
-            [self recalculateViewGeometry];
         });
     } else if (!CGSizeEqualToSize(self.bounds.size, CGSizeZero)) {
         [self recalculateViewGeometry];
@@ -189,6 +188,8 @@
     GLuint framebufferCreationStatus = glCheckFramebufferStatus(GL_FRAMEBUFFER);
     NSAssert(framebufferCreationStatus == GL_FRAMEBUFFER_COMPLETE, @"Failure with display framebuffer generation for display of size: %f, %f", self.bounds.size.width, self.bounds.size.height);
     boundsSizeAtFrameBufferEpoch = self.bounds.size;
+
+    [self recalculateViewGeometry];
 }
 
 - (void)destroyDisplayFramebuffer;


### PR DESCRIPTION
This PR allows you to pause and continue recording with GPUImageMovieWriter with all time samples adjusted appropriately.

Many video apps allow the user to capture & concatenate short bursts of video together into a single video.  This change allows GPUImage to support such functionality.

Note:  it can be viewed as a cleaned up version of https://github.com/BradLarson/GPUImage/pull/1126