### PR TITLE
For SimpleImageFilter example update project file and fix crash

### DIFF
--- a/examples/iOS/SimpleImageFilter/SimpleImageFilter.xcodeproj/project.pbxproj
+++ b/examples/iOS/SimpleImageFilter/SimpleImageFilter.xcodeproj/project.pbxproj
@@ -375,6 +375,7 @@
 		BCB5E80A14E605A900701302 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SimpleImageFilter/SimpleImageFilter-Prefix.pch";
 				INFOPLIST_FILE = "SimpleImageFilter/SimpleImageFilter-Info.plist";
@@ -386,6 +387,7 @@
 		BCB5E80B14E605A900701302 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SimpleImageFilter/SimpleImageFilter-Prefix.pch";
 				INFOPLIST_FILE = "SimpleImageFilter/SimpleImageFilter-Info.plist";

--- a/examples/iOS/SimpleImageFilter/SimpleImageFilter/SimpleImageAppDelegate.m
+++ b/examples/iOS/SimpleImageFilter/SimpleImageFilter/SimpleImageAppDelegate.m
@@ -12,6 +12,7 @@
     
     rootViewController = [[SimpleImageViewController alloc] initWithNibName:nil bundle:nil];
     [self.window addSubview:rootViewController.view];
+    [self.window setRootViewController:rootViewController];
     
     [self.window makeKeyAndVisible];
     return YES;

--- a/examples/iOS/SimpleImageFilter/SimpleImageFilter/SimpleImageAppDelegate.m
+++ b/examples/iOS/SimpleImageFilter/SimpleImageFilter/SimpleImageAppDelegate.m
@@ -11,7 +11,6 @@
     self.window.backgroundColor = [UIColor whiteColor];
     
     rootViewController = [[SimpleImageViewController alloc] initWithNibName:nil bundle:nil];
-    [self.window addSubview:rootViewController.view];
     [self.window setRootViewController:rootViewController];
     
     [self.window makeKeyAndVisible];

--- a/framework/Source/iOS/GPUImageMovieWriter.m
+++ b/framework/Source/iOS/GPUImageMovieWriter.m
@@ -199,9 +199,12 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
     // custom output settings specified
     else 
     {
-		NSString *videoCodec = [outputSettings objectForKey:AVVideoCodecKey];
-		NSNumber *width = [outputSettings objectForKey:AVVideoWidthKey];
-		NSNumber *height = [outputSettings objectForKey:AVVideoHeightKey];
+		NSString *videoCodec;
+		videoCodec = [outputSettings objectForKey:AVVideoCodecKey];
+		NSNumber *width;
+		width = [outputSettings objectForKey:AVVideoWidthKey];
+		NSNumber *height;
+		height = [outputSettings objectForKey:AVVideoHeightKey];
 		
 		NSAssert(videoCodec && width && height, @"OutputSettings is missing required parameters.");
         
@@ -579,7 +582,8 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
     }
     
 	
-	GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+	GLenum status;
+	status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
     
     NSAssert(status == GL_FRAMEBUFFER_COMPLETE, @"Incomplete filter FBO: %d", status);
 }

--- a/framework/Source/iOS/GPUImageView.m
+++ b/framework/Source/iOS/GPUImageView.m
@@ -184,7 +184,8 @@
 
     glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, displayRenderbuffer);
 	
-    GLuint framebufferCreationStatus = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+    GLuint framebufferCreationStatus;
+    framebufferCreationStatus = glCheckFramebufferStatus(GL_FRAMEBUFFER);
     NSAssert(framebufferCreationStatus == GL_FRAMEBUFFER_COMPLETE, @"Failure with display framebuffer generation for display of size: %f, %f", self.bounds.size.width, self.bounds.size.height);
     boundsSizeAtFrameBufferEpoch = self.bounds.size;
 }


### PR DESCRIPTION
App was crashing on launch on iOS 9.  Simple change to add setRootViewController fixes it.
Also updated the project for XCode 7.0
Also fixed those pesky Travis build warnings.