### PR TITLE
Update to use NS_ENUM

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-IOSSDK_VER="7.0"
+IOSSDK_VER="9.0"
 
 # xcodebuild -showsdks
 

--- a/framework/Source/iOS/GPUImageContext.h
+++ b/framework/Source/iOS/GPUImageContext.h
@@ -4,7 +4,16 @@
 
 #define GPUImageRotationSwapsWidthAndHeight(rotation) ((rotation) == kGPUImageRotateLeft || (rotation) == kGPUImageRotateRight || (rotation) == kGPUImageRotateRightFlipVertical || (rotation) == kGPUImageRotateRightFlipHorizontal)
 
-typedef enum { kGPUImageNoRotation, kGPUImageRotateLeft, kGPUImageRotateRight, kGPUImageFlipVertical, kGPUImageFlipHorizonal, kGPUImageRotateRightFlipVertical, kGPUImageRotateRightFlipHorizontal, kGPUImageRotate180 } GPUImageRotationMode;
+typedef NS_ENUM(NSUInteger, GPUImageRotationMode) {
+	kGPUImageNoRotation,
+	kGPUImageRotateLeft,
+	kGPUImageRotateRight,
+	kGPUImageFlipVertical,
+	kGPUImageFlipHorizonal,
+	kGPUImageRotateRightFlipVertical,
+	kGPUImageRotateRightFlipHorizontal,
+	kGPUImageRotate180
+};
 
 @interface GPUImageContext : NSObject
 

--- a/framework/Source/iOS/GPUImageView.h
+++ b/framework/Source/iOS/GPUImageView.h
@@ -1,11 +1,13 @@
 #import <UIKit/UIKit.h>
 #import "GPUImageContext.h"
 
-typedef enum {
+typedef NS_ENUM(NSUInteger, GPUImageFillModeType) {
     kGPUImageFillModeStretch,                       // Stretch to fill the full view, which may distort the image outside of its normal aspect ratio
     kGPUImageFillModePreserveAspectRatio,           // Maintains the aspect ratio of the source image, adding bars of the specified background color
     kGPUImageFillModePreserveAspectRatioAndFill     // Maintains the aspect ratio of the source image, zooming in on its center to fill the view
-} GPUImageFillModeType; 
+};
+
+
 
 /**
  UIView subclass to use as an endpoint for displaying GPUImage outputs


### PR DESCRIPTION
C++ `typedef enum` seems to cause problems when projects use both Objective C and Swift, you get an `ambiguous usage of GPUImageFillModeType` error. This compiles better.

Also updates the build.sh to use ios9 instead of 7 as that's pretty old.