### PR TITLE
Fixed computation mistake in GPUImageAverageColor

### DIFF
--- a/framework/Source/GPUImageAverageColor.m
+++ b/framework/Source/GPUImageAverageColor.m
@@ -131,12 +131,6 @@ NSString *const kGPUImageColorAveragingFragmentShaderString = SHADER_STRING
     for (NSUInteger currentReduction = 0; currentReduction < reductionsToHitSideLimit; currentReduction++)
     {
         CGSize currentStageSize = CGSizeMake(floor(inputTextureSize.width / pow(4.0, currentReduction + 1.0)), floor(inputTextureSize.height / pow(4.0, currentReduction + 1.0)));
-        if ( (currentStageSize.height < 2.0) || (currentStageSize.width < 2.0) )
-        {
-            // A really small last stage seems to cause significant errors in the average, so I abort and leave the rest to the CPU at this point
-            break;
-            //                currentStageSize.height = 2.0; // TODO: Rotate the image to account for this case, which causes FBO construction to fail
-        }
 
         [outputFramebuffer unlock];
         outputFramebuffer = [[GPUImageContext sharedFramebufferCache] fetchFramebufferForSize:currentStageSize textureOptions:self.outputTextureOptions onlyTexture:NO];
@@ -150,8 +144,8 @@ NSString *const kGPUImageColorAveragingFragmentShaderString = SHADER_STRING
         
         glUniform1i(filterInputTextureUniform, 2);
         
-        glUniform1f(texelWidthUniform, 0.5 / currentStageSize.width);
-        glUniform1f(texelHeightUniform, 0.5 / currentStageSize.height);
+        glUniform1f(texelWidthUniform, 0.25 / currentStageSize.width);
+        glUniform1f(texelHeightUniform, 0.25 / currentStageSize.height);
         
         glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 

--- a/framework/Source/iOS/GPUImageMovieWriter.m
+++ b/framework/Source/iOS/GPUImageMovieWriter.m
@@ -199,9 +199,9 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
     // custom output settings specified
     else 
     {
-		NSString *videoCodec = [outputSettings objectForKey:AVVideoCodecKey];
-		NSNumber *width = [outputSettings objectForKey:AVVideoWidthKey];
-		NSNumber *height = [outputSettings objectForKey:AVVideoHeightKey];
+		__unused NSString *videoCodec = [outputSettings objectForKey:AVVideoCodecKey];
+		__unused NSNumber *width = [outputSettings objectForKey:AVVideoWidthKey];
+		__unused NSNumber *height = [outputSettings objectForKey:AVVideoHeightKey];
 		
 		NSAssert(videoCodec && width && height, @"OutputSettings is missing required parameters.");
         
@@ -579,7 +579,7 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
     }
     
 	
-	GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+	__unused GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
     
     NSAssert(status == GL_FRAMEBUFFER_COMPLETE, @"Incomplete filter FBO: %d", status);
 }

--- a/framework/Source/iOS/GPUImageView.m
+++ b/framework/Source/iOS/GPUImageView.m
@@ -184,7 +184,7 @@
 
     glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, displayRenderbuffer);
 	
-    GLuint framebufferCreationStatus = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+    __unused GLuint framebufferCreationStatus = glCheckFramebufferStatus(GL_FRAMEBUFFER);
     NSAssert(framebufferCreationStatus == GL_FRAMEBUFFER_COMPLETE, @"Failure with display framebuffer generation for display of size: %f, %f", self.bounds.size.width, self.bounds.size.height);
     boundsSizeAtFrameBufferEpoch = self.bounds.size;
 }


### PR DESCRIPTION
Wrong pixels were addressed.

Averaging the following images was leading to average colors (1.0, 1.0, 1.0, 1.0) and (0.0, 0.0, 0.0, 1.0).
It should have been close to (0.75, 0.75, 0.75, 1.0) for both.
![averagetest1](https://cloud.githubusercontent.com/assets/16095888/11508470/57d4f730-9859-11e5-907d-aa4cefcaa473.png)
![averagetest2](https://cloud.githubusercontent.com/assets/16095888/11508469/57d2d7f2-9859-11e5-8cda-982a7781b0c0.png)

Once the texelWidthUniform & texelHeightUniform computation fixed, I did not notice any "significant errors" while computing the average of the 2 images without the following code:
```objective-c
        if ( (currentStageSize.height < 2.0) || (currentStageSize.width < 2.0) )
        {
            // A really small last stage seems to cause significant errors in the average, so I abort and leave the rest to the CPU at this point
            break;
        }
```
so I removed it.