### PR TITLE
Fatal missing NS_ENUM for GPUImageSkinToneFilter

### DIFF
--- a/framework/Source/GPUImageSkinToneFilter.h
+++ b/framework/Source/GPUImageSkinToneFilter.h
@@ -10,7 +10,7 @@
 
 typedef NS_ENUM(NSUInteger, GPUImageSkinToneUpperColor) {
     GPUImageSkinToneUpperColorGreen,
-     
+    GPUImageSkinToneUpperColorOrange
 };
 
 extern NSString *const kGPUImageSkinToneFragmentShaderString;


### PR DESCRIPTION
@BradLarson this is a critical fix for GPUImageSkinToneFilter; somehow the NS_ENUM was missing the second param.