### PR TITLE
add sourceFormatHint for audio input in GPUImageMovieWriter

### DIFF
--- a/framework/Source/Mac/GPUImageMovieWriter.h
+++ b/framework/Source/Mac/GPUImageMovieWriter.h
@@ -44,6 +44,7 @@ extern NSString *const kGPUImageColorSwizzlingFragmentShaderString;
 - (id)initWithMovieURL:(NSURL *)newMovieURL size:(CGSize)newSize fileType:(NSString *)newFileType outputSettings:(NSMutableDictionary *)outputSettings;
 
 - (void)setHasAudioTrack:(BOOL)hasAudioTrack audioSettings:(NSDictionary *)audioOutputSettings;
+- (void)setHasAudioTrack:(BOOL)hasAudioTrack audioSettings:(NSDictionary *)audioOutputSettings sourceFormatHint:(CMFormatDescriptionRef)sourceFormatHint;
 
 // Movie recording
 - (void)startRecording;

--- a/framework/Source/Mac/GPUImageMovieWriter.m
+++ b/framework/Source/Mac/GPUImageMovieWriter.m
@@ -588,7 +588,7 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
 	[self setHasAudioTrack:newValue audioSettings:nil];
 }
 
-- (void)setHasAudioTrack:(BOOL)newValue audioSettings:(NSDictionary *)audioOutputSettings;
+- (void)setHasAudioTrack:(BOOL)newValue audioSettings:(NSDictionary *)audioOutputSettings sourceFormatHint:(CMFormatDescriptionRef)sourceFormatHint
 {
     _hasAudioTrack = newValue;
     
@@ -630,7 +630,11 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
                                    nil];*/
         }
         
-        assetWriterAudioInput = [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeAudio outputSettings:audioOutputSettings];
+        if ([AVAssetWriterInput respondsToSelector:@selector(assetWriterInputWithMediaType:outputSettings:sourceFormatHint:)]) {
+            assetWriterAudioInput = [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeAudio outputSettings:audioOutputSettings sourceFormatHint:sourceFormatHint];
+        } else {
+            assetWriterAudioInput = [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeAudio outputSettings:audioOutputSettings];
+        }
         [assetWriter addInput:assetWriterAudioInput];
         assetWriterAudioInput.expectsMediaDataInRealTime = _encodingLiveVideo;
     }
@@ -640,5 +644,8 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
     }
 }
 
+- (void)setHasAudioTrack:(BOOL)hasAudioTrack audioSettings:(NSDictionary *)audioOutputSettings {
+    [self setHasAudioTrack:hasAudioTrack audioSettings:audioOutputSettings sourceFormatHint:NULL];
+}
 
 @end

--- a/framework/Source/iOS/GPUImageMovieWriter.h
+++ b/framework/Source/iOS/GPUImageMovieWriter.h
@@ -54,6 +54,7 @@ extern NSString *const kGPUImageColorSwizzlingFragmentShaderString;
 - (id)initWithMovieURL:(NSURL *)newMovieURL size:(CGSize)newSize fileType:(NSString *)newFileType outputSettings:(NSDictionary *)outputSettings;
 
 - (void)setHasAudioTrack:(BOOL)hasAudioTrack audioSettings:(NSDictionary *)audioOutputSettings;
+- (void)setHasAudioTrack:(BOOL)hasAudioTrack audioSettings:(NSDictionary *)audioOutputSettings sourceFormatHint:(CMFormatDescriptionRef)sourceFormatHint;
 
 // Movie recording
 - (void)startRecording;

--- a/framework/Source/iOS/GPUImageMovieWriter.m
+++ b/framework/Source/iOS/GPUImageMovieWriter.m
@@ -891,7 +891,7 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
 	[self setHasAudioTrack:newValue audioSettings:nil];
 }
 
-- (void)setHasAudioTrack:(BOOL)newValue audioSettings:(NSDictionary *)audioOutputSettings;
+- (void)setHasAudioTrack:(BOOL)newValue audioSettings:(NSDictionary *)audioOutputSettings sourceFormatHint:(CMFormatDescriptionRef)sourceFormatHint
 {
     _hasAudioTrack = newValue;
     
@@ -945,7 +945,11 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
                                    nil];*/
         }
         
-        assetWriterAudioInput = [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeAudio outputSettings:audioOutputSettings];
+        if ([AVAssetWriterInput respondsToSelector:@selector(assetWriterInputWithMediaType:outputSettings:sourceFormatHint:)]) {
+            assetWriterAudioInput = [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeAudio outputSettings:audioOutputSettings sourceFormatHint:sourceFormatHint];
+        } else {
+            assetWriterAudioInput = [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeAudio outputSettings:audioOutputSettings];
+        }
         [assetWriter addInput:assetWriterAudioInput];
         assetWriterAudioInput.expectsMediaDataInRealTime = _encodingLiveVideo;
     }
@@ -953,6 +957,10 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
     {
         // Remove audio track if it exists
     }
+}
+
+- (void)setHasAudioTrack:(BOOL)hasAudioTrack audioSettings:(NSDictionary *)audioOutputSettings {
+    [self setHasAudioTrack:hasAudioTrack audioSettings:audioOutputSettings sourceFormatHint:NULL];
 }
 
 - (NSArray*)metaData {


### PR DESCRIPTION
Make AVAssetWriterInput use the new initializer `+ (AVAssetWriterInput *)assetWriterInputWithMediaType:(NSString *)mediaType outputSettings:(NSDictionary *)outputSettings sourceFormatHint:(CMFormatDescriptionRef)sourceFormatHint NS_AVAILABLE(10_8, 6_0);` which includes the ability to hint at the format of media data that will be appended to the new instance of AVAssetWriterInput.

This gives the GPUImageMovieWriter the ability to write video with audio tracks in mp4 (AVFileTypeMPEG4) format.

For example:
```
GPUImageMovie *movie = [[GPUImageMovie alloc] initWithURL:videoURL];
GPUImageMovieWriter *movieWriter = [[GPUImageMovieWriter alloc] initWithMovieURL:processedVideoFileURL size:videoSize fileType:AVFileTypeMPEG4 outputSettings:...];
[movie enableSynchronizedEncodingUsingMovieWriter:movieWriter];
movieWriter.shouldPassthroughAudio = YES;
AVAssetTrack *audioTrack = [videoAsset tracksWithMediaType:AVMediaTypeAudio].firstObject;
if (audioTrack) {
    CMAudioFormatDescriptionRef sourceFormatHint = (__bridge CMAudioFormatDescriptionRef)([audioTrack formatDescriptions].firstObject);
    [movieWriter setHasAudioTrack:YES audioSettings:nil sourceFormatHint:sourceFormatHint];
    movie.audioEncodingTarget = movieWriter;
}
[movieWriter startRecording];
[movie startProcessing];
```