### PR TITLE
Set root view controller of the main window

### DIFF
--- a/examples/iOS/ColorObjectTracking/ColorObjectTracking/ColorTrackingAppDelegate.m
+++ b/examples/iOS/ColorObjectTracking/ColorObjectTracking/ColorTrackingAppDelegate.m
@@ -10,8 +10,7 @@
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     self.window.backgroundColor = [UIColor whiteColor];
     
-    colorTrackingViewController = [[ColorTrackingViewController alloc] initWithNibName:nil bundle:nil];
-    [self.window addSubview:colorTrackingViewController.view];
+    self.window.rootViewController = [[ColorTrackingViewController alloc] initWithNibName:nil bundle:nil];
     
     [self.window makeKeyAndVisible];
     return YES;


### PR DESCRIPTION
Application fro m `ColorObjectTracking` project crashes before root view controller of the main window isn't set after 'application:didFinishLaunchingWithOptions:' method finishes.

This PR fixes that.