### PR TITLE
fix issue #2221

### DIFF
--- a/framework/Source/GPUImageMovie.m
+++ b/framework/Source/GPUImageMovie.m
@@ -585,6 +585,10 @@ static CVReturn renderCallback(CVDisplayLinkRef displayLink,
         //        if (captureAsYUV && [GPUImageContext deviceSupportsRedTextures])
         if (CVPixelBufferGetPlaneCount(movieFrame) > 0) // Check for YUV planar inputs to do RGB conversion
         {
+            
+            // fix issue 2221
+            CVPixelBufferLockBaseAddress(movieFrame,0);
+        
 
             if ( (imageBufferWidth != bufferWidth) && (imageBufferHeight != bufferHeight) )
             {


### PR DESCRIPTION
In GPUImageMovie missing a CVPixelBufferLockBaseAddress function call.