### PR TITLE
removed ‘GPUImageMovie’ from the excluded files for OS X.

### DIFF
--- a/GPUImage.podspec
+++ b/GPUImage.podspec
@@ -19,7 +19,6 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.6'
   s.osx.exclude_files = 'framework/Source/iOS',
                         'framework/Source/GPUImageFilterPipeline.*',
-                        'framework/Source/GPUImageMovie.*',
                         'framework/Source/GPUImageMovieComposition.*',
                         'framework/Source/GPUImageVideoCamera.*',
                         'framework/Source/GPUImageStillCamera.*',


### PR DESCRIPTION
It can be built for OS X