### PR TITLE
GPUImageFramebuffer  add  get   CVPixelBufferRef  method,  VideoToolB…

### DIFF
--- a/framework/Source/GPUImageFramebuffer.h
+++ b/framework/Source/GPUImageFramebuffer.h
@@ -54,5 +54,6 @@ typedef struct GPUTextureOptions {
 - (void)unlockAfterReading;
 - (NSUInteger)bytesPerRow;
 - (GLubyte *)byteBuffer;
+- (CVPixelBufferRef)pixelBuffer;
 
 @end

--- a/framework/Source/GPUImageFramebuffer.m
+++ b/framework/Source/GPUImageFramebuffer.m
@@ -439,6 +439,15 @@ void dataProviderUnlockCallback (void *info, const void *data, size_t size)
 #endif
 }
 
+- (CVPixelBufferRef )pixelBuffer;
+{
+#if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
+    return renderTarget;
+#else
+    return NULL; // TODO: do more with this on the non-texture-cache side
+#endif
+}
+
 - (GLuint)texture;
 {
 //    NSLog(@"Accessing texture: %d from FB: %@", _texture, self);


### PR DESCRIPTION
VideoToolBox   encode  need CVPixelBufferRef  format，otherwise  need  createPixelBuffer  for  bytes , Modified can Better performance。（VideotoolBox 硬件编码器需要CVPixelBufferRef 格式，但目前只能通过bytes来创建，浪费性能，这样速度好一些 ）