### PR TITLE
Avoid pushing old frames.

### DIFF
--- a/framework/Source/iOS/GPUImageMovieWriter.m
+++ b/framework/Source/iOS/GPUImageMovieWriter.m
@@ -460,7 +460,10 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
                 //NSLog(@"audio waiting...");
                 [[NSRunLoop currentRunLoop] runUntilDate:maxDate];
             }
-            if (!assetWriterAudioInput.readyForMoreMediaData)
+            if (previousFrameTime.value >= currentSampleTime.value)
+            {
+                NSLog(@"Skipping invalid frame (behind previousFrameTime");
+            } else if (!assetWriterAudioInput.readyForMoreMediaData)
             {
                 NSLog(@"2: Had to drop an audio frame %@", CFBridgingRelease(CMTimeCopyDescription(kCFAllocatorDefault, currentSampleTime)));
             }


### PR DESCRIPTION
It was trying to push old frames, e.g. pushed frame with value 10, then tried to push frame with value 9 and that changed the status to AVAssetWriterStatusFailed.

I was hitting this issue on GPUImage, my video was laggy because of other process that i'm running on it.

see http://stackoverflow.com/a/22385536/688379
