### PR TITLE
fix: avoid process movie on the main thread

### DIFF
--- a/framework/Source/GPUImageMovie.m
+++ b/framework/Source/GPUImageMovie.m
@@ -166,7 +166,9 @@
     }
     if(self.url == nil)
     {
-      [self processAsset];
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        [self processAsset];
+    });
       return;
     }
     

--- a/framework/Source/GPUImageMovie.m
+++ b/framework/Source/GPUImageMovie.m
@@ -160,6 +160,8 @@
 
 - (void)startProcessing
 {
+    if (_shouldRepeat) keepLooping = YES;
+    
     if( self.playerItem ) {
         [self processPlayerItem];
         return;
@@ -171,8 +173,6 @@
     });
       return;
     }
-    
-    if (_shouldRepeat) keepLooping = YES;
     
     previousFrameTime = kCMTimeZero;
     previousActualFrameTime = CFAbsoluteTimeGetCurrent();


### PR DESCRIPTION
If i create a GPUImageMovie object using initWithAsset: method,and just call startProcessing method without add GPUImageMovieWriter target. The processing loop will run on the main thread,  then the movie will not shown until process finished.
