### PR TITLE
GPUImageMovie and GPUImageMovieWriter enhancements

### DIFF
--- a/framework/Source/GPUImageMovie.m
+++ b/framework/Source/GPUImageMovie.m
@@ -90,6 +90,10 @@
     self.url = nil;
     self.asset = nil;
     self.playerItem = playerItem;
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(playerItemDidFinishPlaying:)
+                                                 name:AVPlayerItemDidPlayToEndTimeNotification
+                                               object:playerItem];
 
     return self;
 }
@@ -409,6 +413,13 @@ static CVReturn renderCallback(CVDisplayLinkRef displayLink,
                 [weakSelf processMovieFrame:pixelBuffer withSampleTime:outputItemTime];
                 CFRelease(pixelBuffer);
             });
+    }
+}
+
+- (void)playerItemDidFinishPlaying:(NSNotification *)notification
+{
+    if ([self.delegate respondsToSelector:@selector(didCompletePlayingMovie)]) {
+        [self.delegate didCompletePlayingMovie];
     }
 }
 

--- a/framework/Source/iOS/GPUImageMovieWriter.h
+++ b/framework/Source/iOS/GPUImageMovieWriter.h
@@ -10,6 +10,10 @@ extern NSString *const kGPUImageColorSwizzlingFragmentShaderString;
 - (void)movieRecordingCompleted;
 - (void)movieRecordingFailedWithError:(NSError*)error;
 
+/**
+ * Progress of writing in range 0.0 to 1.0.
+ */
+- (void)writingProgress:(CGFloat)progress;
 @end
 
 @interface GPUImageMovieWriter : NSObject <GPUImageInput>
@@ -48,6 +52,9 @@ extern NSString *const kGPUImageColorSwizzlingFragmentShaderString;
 @property(nonatomic, copy) NSArray *metaData;
 @property(nonatomic, assign, getter = isPaused) BOOL paused;
 @property(nonatomic, retain) GPUImageContext *movieWriterContext;
+// In videofile re-encoding populate this variable before write, in order to receive delegate
+// callbacks to 'writingProgress' method of the writing progress.
+@property (nonatomic) CGFloat sourceDurationInSeconds;
 
 // Initialization and teardown
 - (id)initWithMovieURL:(NSURL *)newMovieURL size:(CGSize)newSize;

--- a/framework/Source/iOS/GPUImageMovieWriter.m
+++ b/framework/Source/iOS/GPUImageMovieWriter.m
@@ -810,6 +810,12 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
             
             previousFrameTime = frameTime;
             
+            if (self.delegate && self.sourceDurationInSeconds > 0) {
+                CGFloat moviePosition = CMTimeGetSeconds(frameTime);
+                CGFloat progress = (moviePosition/self.sourceDurationInSeconds);
+                [self.delegate writingProgress:progress];
+            }
+
             if (![GPUImageContext supportsFastTextureUpload])
             {
                 CVPixelBufferRelease(pixel_buffer);


### PR DESCRIPTION
1) Once GPUImageMovie has been constructed for playback using AVPlayerItem, send back notification to the delegate once playback has completed
2) When encoding + rewriting movie with GPUImageMovieWriter enable progress callbacks to the delegate
