### PR TITLE
Fixed 2 old issues.

### DIFF
--- a/framework/Source/GPUImageFilter.m
+++ b/framework/Source/GPUImageFilter.m
@@ -156,6 +156,11 @@ NSString *const kGPUImagePassthroughFragmentShaderString = SHADER_STRING
 
 - (void)dealloc
 {
+	//related issue : https://github.com/BradLarson/GPUImage/issues/2191
+    runAsynchronouslyOnVideoProcessingQueue(^{
+        firstInputFramebuffer = nil;
+    });
+    
 #if !OS_OBJECT_USE_OBJC
     if (imageCaptureSemaphore != NULL)
     {

--- a/framework/Source/GPUImageMaskFilter.m
+++ b/framework/Source/GPUImageMaskFilter.m
@@ -67,7 +67,7 @@ NSString *const kGPUImageMaskShaderString = SHADER_STRING
 - (void)renderToTextureWithVertices:(const GLfloat *)vertices textureCoordinates:(const GLfloat *)textureCoordinates;
 {
     glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA); //removed jagged edge (an issue with premultiplied alpha)
     [super renderToTextureWithVertices:vertices textureCoordinates:textureCoordinates];
     glDisable(GL_BLEND);
 }


### PR DESCRIPTION
- fixed an important memory related issue about GPUImageFrameBuffer dealloc 
- fixed an issue about premultiplied alpha (removed jagged edge)

Especially a modification (of course, that is not perfect solution) for first issue, memory leak related commit was pefectly works in my case even when pretty big or heavy processing was performed with GPUImagePicture. If I do remove that line, framebuffer will not disapear never. Confirm please or tell me some advice for correct way if you can, @BradLarson