### PR TITLE
Fixed frames drop (black frame) when recording video with audio

### DIFF
--- a/framework/Source/iOS/GPUImageMovieWriter.m
+++ b/framework/Source/iOS/GPUImageMovieWriter.m
@@ -35,6 +35,7 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
     BOOL audioEncodingIsFinished, videoEncodingIsFinished;
 
     BOOL isRecording;
+    BOOL allowWriteAudio;
 }
 
 // Movie recording
@@ -278,6 +279,8 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
         }
     });
     isRecording = YES;
+    allowWriteAudio = NO;
+  
 	//    [assetWriter startSessionAtSourceTime:kCMTimeZero];
 }
 
@@ -365,6 +368,11 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
 
 - (void)processAudioBuffer:(CMSampleBufferRef)audioBuffer;
 {
+  
+    if (!allowWriteAudio) {
+        return;
+    }
+  
     if (!isRecording || _paused)
     {
         return;
@@ -800,6 +808,7 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
             {
                 if (![assetWriterPixelBufferInput appendPixelBuffer:pixel_buffer withPresentationTime:frameTime])
                     NSLog(@"Problem appending pixel buffer at time: %@", CFBridgingRelease(CMTimeCopyDescription(kCFAllocatorDefault, frameTime)));
+                allowWriteAudio = YES;
             }
             else
             {


### PR DESCRIPTION
I was having an issue that caused some video records to have black frames at the end. It was happening because the audio track was longer than the video track.

Adding a property to avoid audio recording when there is no video recorded fixed this issue.