### PR TITLE
fix YUV to RGB color conversion matrix

### DIFF
--- a/framework/Source/GPUImageColorConversion.m
+++ b/framework/Source/GPUImageColorConversion.m
@@ -18,9 +18,9 @@ GLfloat kColorConversion601FullRangeDefault[] = {
 
 // BT.709, which is the standard for HDTV.
 GLfloat kColorConversion709Default[] = {
-    1.164,  1.164, 1.164,
-    0.0, -0.213, 2.112,
-    1.793, -0.533,   0.0,
+    1.0,    1.0,    1.0,
+    0.0,    -0.187, 1.856,
+    1.575,    -0.468, 0.0,
 };
 
 

--- a/framework/Source/GPUImageMovie.m
+++ b/framework/Source/GPUImageMovie.m
@@ -166,7 +166,9 @@
     }
     if(self.url == nil)
     {
-      [self processAsset];
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        [self processAsset];
+    });
       return;
     }
     

--- a/framework/Source/GPUImageMovie.m
+++ b/framework/Source/GPUImageMovie.m
@@ -160,6 +160,8 @@
 
 - (void)startProcessing
 {
+    if (_shouldRepeat) keepLooping = YES;
+    
     if( self.playerItem ) {
         [self processPlayerItem];
         return;
@@ -171,8 +173,6 @@
     });
       return;
     }
-    
-    if (_shouldRepeat) keepLooping = YES;
     
     previousFrameTime = kCMTimeZero;
     previousActualFrameTime = CFAbsoluteTimeGetCurrent();


### PR DESCRIPTION
Videos exported using kColorConversion709Default conversion matrix is lighter then origin one. I suppose The original format is 'YPbPr' when configuring format value with 'kCVPixelFormatType_420YpCbCr8BiPlanarFullRange' in outputSettings. The conversion matrix from YUV to RGB should be changed.
reference:http://www.equasys.de/colorconversion.html