### PR TITLE
fix gaussianSelectiveBlur not a perfect circle

### DIFF
--- a/framework/Source/GPUImageGaussianSelectiveBlurFilter.m
+++ b/framework/Source/GPUImageGaussianSelectiveBlurFilter.m
@@ -21,8 +21,10 @@ NSString *const kGPUImageGaussianSelectiveBlurFragmentShaderString = SHADER_STRI
      lowp vec4 sharpImageColor = texture2D(inputImageTexture, textureCoordinate);
      lowp vec4 blurredImageColor = texture2D(inputImageTexture2, textureCoordinate2);
      
-     highp vec2 textureCoordinateToUse = vec2(textureCoordinate2.x, (textureCoordinate2.y * aspectRatio + 0.5 - 0.5 * aspectRatio));
-     highp float distanceFromCenter = distance(excludeCirclePoint, textureCoordinateToUse);
+     highp vec2 scaledTextureCoordinate = vec2(textureCoordinate2.x, textureCoordinate2.y / aspectRatio);
+     lowp vec2 scaledExcludeCirclePoint = vec2(excludeCirclePoint.x, excludeCirclePoint.y / aspectRatio);
+     
+     highp float distanceFromCenter = distance(scaledExcludeCirclePoint, scaledTextureCoordinate);
      
      gl_FragColor = mix(sharpImageColor, blurredImageColor, smoothstep(excludeCircleRadius - excludeBlurSize, excludeCircleRadius, distanceFromCenter));
  }
@@ -46,8 +48,10 @@ NSString *const kGPUImageGaussianSelectiveBlurFragmentShaderString = SHADER_STRI
      vec4 sharpImageColor = texture2D(inputImageTexture, textureCoordinate);
      vec4 blurredImageColor = texture2D(inputImageTexture2, textureCoordinate2);
      
-     vec2 textureCoordinateToUse = vec2(textureCoordinate2.x, (textureCoordinate2.y * aspectRatio + 0.5 - 0.5 * aspectRatio));
-     float distanceFromCenter = distance(excludeCirclePoint, textureCoordinateToUse);
+     vec2 scaledTextureCoordinate = vec2(textureCoordinate2.x, textureCoordinate2.y / aspectRatio);
+     vec2 scaledExcludeCirclePoint = vec2(excludeCirclePoint.x, excludeCirclePoint.y / aspectRatio);
+     
+     float distanceFromCenter = distance(scaledExcludeCirclePoint, scaledTextureCoordinate);
      
      gl_FragColor = mix(sharpImageColor, blurredImageColor, smoothstep(excludeCircleRadius - excludeBlurSize, excludeCircleRadius, distanceFromCenter));
  }

--- a/framework/Source/iOS/GPUImageMovieWriter.h
+++ b/framework/Source/iOS/GPUImageMovieWriter.h
@@ -15,12 +15,13 @@ extern NSString *const kGPUImageColorSwizzlingFragmentShaderString;
 @interface GPUImageMovieWriter : NSObject <GPUImageInput>
 {
     BOOL alreadyFinishedRecording;
+    BOOL allowWriteAudio;
     
     NSURL *movieURL;
     NSString *fileType;
-	AVAssetWriter *assetWriter;
-	AVAssetWriterInput *assetWriterAudioInput;
-	AVAssetWriterInput *assetWriterVideoInput;
+    AVAssetWriter *assetWriter;
+    AVAssetWriterInput *assetWriterAudioInput;
+    AVAssetWriterInput *assetWriterVideoInput;
     AVAssetWriterInputPixelBufferAdaptor *assetWriterPixelBufferInput;
     
     GPUImageContext *_movieWriterContext;

--- a/framework/Source/iOS/GPUImageMovieWriter.m
+++ b/framework/Source/iOS/GPUImageMovieWriter.m
@@ -27,9 +27,8 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
 
     GPUImageFramebuffer *firstInputFramebuffer;
     
-    BOOL discont;
     CMTime startTime, previousFrameTime, previousAudioTime;
-    CMTime offsetTime;
+    CMTime offsetTime, rawFrameTime;
     
     dispatch_queue_t audioQueue, videoQueue;
     BOOL audioEncodingIsFinished, videoEncodingIsFinished;
@@ -87,7 +86,6 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
     videoEncodingIsFinished = NO;
     audioEncodingIsFinished = NO;
 
-    discont = NO;
     videoSize = newSize;
     movieURL = newMovieURL;
     fileType = newFileType;
@@ -95,6 +93,8 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
     _encodingLiveVideo = [[outputSettings objectForKey:@"EncodingLiveVideo"] isKindOfClass:[NSNumber class]] ? [[outputSettings objectForKey:@"EncodingLiveVideo"] boolValue] : YES;
     previousFrameTime = kCMTimeNegativeInfinity;
     previousAudioTime = kCMTimeNegativeInfinity;
+    offsetTime = kCMTimeZero;
+    rawFrameTime = kCMTimeZero;
     inputRotation = kGPUImageNoRotation;
     
     _movieWriterContext = [[GPUImageContext alloc] init];
@@ -279,6 +279,7 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
     });
     isRecording = YES;
 	//    [assetWriter startSessionAtSourceTime:kCMTimeZero];
+    allowWriteAudio = NO;
 }
 
 - (void)startRecordingInOrientation:(CGAffineTransform)orientationTransform;
@@ -369,6 +370,9 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
     {
         return;
     }
+    if (!allowWriteAudio) {
+        return;
+    }
     
 //    if (_hasAudioTrack && CMTIME_IS_VALID(startTime))
     if (_hasAudioTrack)
@@ -400,33 +404,9 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
             return;
         }
         
-        if (discont) {
-            discont = NO;
-            
-            CMTime current;
-            if (offsetTime.value > 0) {
-                current = CMTimeSubtract(currentSampleTime, offsetTime);
-            } else {
-                current = currentSampleTime;
-            }
-            
-            CMTime offset = CMTimeSubtract(current, previousAudioTime);
-            
-            if (offsetTime.value == 0) {
-                offsetTime = offset;
-            } else {
-                offsetTime = CMTimeAdd(offsetTime, offset);
-            }
-        }
-        
         if (offsetTime.value > 0) {
-            CFRelease(audioBuffer);
-            audioBuffer = [self adjustTime:audioBuffer by:offsetTime];
-            CFRetain(audioBuffer);
+            currentSampleTime = CMTimeSubtract(currentSampleTime, offsetTime);
         }
-        
-        // record most recent time so we know the length of the pause
-        currentSampleTime = CMSampleBufferGetPresentationTimeStamp(audioBuffer);
 
         previousAudioTime = currentSampleTime;
         
@@ -697,29 +677,11 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
 
 - (void)newFrameReadyAtTime:(CMTime)frameTime atIndex:(NSInteger)textureIndex;
 {
+    rawFrameTime = frameTime;
     if (!isRecording || _paused)
     {
         [firstInputFramebuffer unlock];
         return;
-    }
-
-    if (discont) {
-        discont = NO;
-        CMTime current;
-        
-        if (offsetTime.value > 0) {
-            current = CMTimeSubtract(frameTime, offsetTime);
-        } else {
-            current = frameTime;
-        }
-        
-        CMTime offset  = CMTimeSubtract(current, previousFrameTime);
-        
-        if (offsetTime.value == 0) {
-            offsetTime = offset;
-        } else {
-            offsetTime = CMTimeAdd(offsetTime, offset);
-        }
     }
     
     if (offsetTime.value > 0) {
@@ -800,6 +762,7 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
             {
                 if (![assetWriterPixelBufferInput appendPixelBuffer:pixel_buffer withPresentationTime:frameTime])
                     NSLog(@"Problem appending pixel buffer at time: %@", CFBridgingRelease(CMTimeCopyDescription(kCFAllocatorDefault, frameTime)));
+                allowWriteAudio = YES;
             }
             else
             {
@@ -986,13 +949,23 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
 }
 
 - (void)setPaused:(BOOL)newValue {
+    if (!isRecording) return;
     if (_paused != newValue) {
-        _paused = newValue;
-        
-        if (_paused) {
-            discont = YES;
+    
+        if (!newValue) {
+            CMTime rawPausedTime;
+            if (!CMTIME_IS_NEGATIVE_INFINITY(previousFrameTime)) {
+                rawPausedTime = CMTimeAdd(previousFrameTime, offsetTime);
+            }else if (!CMTIME_IS_NEGATIVE_INFINITY(previousAudioTime)) {
+                rawPausedTime = CMTimeAdd(previousAudioTime, offsetTime);
+            }else {
+                rawPausedTime = offsetTime;
+            }
+            CMTime offset = CMTimeSubtract(rawFrameTime, rawPausedTime);
+            offsetTime = CMTimeAdd(offsetTime, offset);
         }
-    }
+        _paused = newValue;
+	}
 }
 
 - (CMSampleBufferRef)adjustTime:(CMSampleBufferRef) sample by:(CMTime) offset {

--- a/framework/Source/iOS/GPUImageMovieWriter.m
+++ b/framework/Source/iOS/GPUImageMovieWriter.m
@@ -279,7 +279,11 @@ NSString *const kGPUImageColorSwizzlingFragmentShaderString = SHADER_STRING
     });
     isRecording = YES;
 	//    [assetWriter startSessionAtSourceTime:kCMTimeZero];
-    allowWriteAudio = NO;
+    if (_encodingLiveVideo) {
+        allowWriteAudio = NO;
+    }else {
+        allowWriteAudio = YES;
+    }
 }
 
 - (void)startRecordingInOrientation:(CGAffineTransform)orientationTransform;


### PR DESCRIPTION
Using GPUImageGaussianSelectiveBlurFilter results in an oval region but not a perfect circle:
![issue1](https://user-images.githubusercontent.com/11287332/30732734-8a329b50-9fa6-11e7-8b04-dca55e4b6b17.png)
We can fix it by setting aspectRatio, but another issue occur. When I set excludeCirclePoint to (1.0, 1.0), I found that center of the circle not exactly at bottom-right:
![issue2](https://user-images.githubusercontent.com/11287332/30732864-10bec75c-9fa7-11e7-964e-5627be3db6a8.png)
I fixed the shader string:
![fix1](https://user-images.githubusercontent.com/11287332/30733017-bc3dc02e-9fa7-11e7-9eec-3e00ee43bea8.png)
![fix2](https://user-images.githubusercontent.com/11287332/30733019-bffdfb98-9fa7-11e7-8d64-6124a7a8ebf1.png)
Now it's a perfect circle and align any corner exactly.