### PR TITLE
GPUImageMovie endprocessing crash issue.

### DIFF
--- a/framework/Source/GPUImageMovie.m
+++ b/framework/Source/GPUImageMovie.m
@@ -812,6 +812,12 @@ static CVReturn renderCallback(CVDisplayLinkRef displayLink,
         [self.delegate didCompletePlayingMovie];
     }
     self.delegate = nil;
+    
+    runSynchronouslyOnVideoProcessingQueue(^{
+        [playerItemOutput setDelegate: nil queue: nil];
+        [_playerItem removeOutput: playerItemOutput];
+        playerItemOutput = nil;
+    });
 }
 
 - (void)cancelProcessing


### PR DESCRIPTION
AVPlayerItemVideoOutput property inside GPUImageMovie sets videoProcessingQueue as a delegate, so when GPUImageMovie is deallocating, AVPlayerItemVideoOutput won't release then the crash occurs. To fix it, we need to make sure that AVPlayerItemVideoOutput is released properly when the process ends. Hence the following codes are provided at the end of endProcessing method.

References:
https://github.com/BradLarson/GPUImage/issues/1994
https://stackoverflow.com/questions/29103254/copy-helper-block-crash-in-avfoundation