### PR TITLE
Fix leak in GPUImageContext

### DIFF
--- a/framework/Source/iOS/GPUImageContext.m
+++ b/framework/Source/iOS/GPUImageContext.m
@@ -44,6 +44,12 @@ static void *openGLESContextQueueKey;
     return self;
 }
 
+- (void)dealloc {
+    if (_coreVideoTextureCache != NULL) {
+        CFRelease(_coreVideoTextureCache);
+    }
+}
+
 + (void *)contextKey {
 	return openGLESContextQueueKey;
 }


### PR DESCRIPTION
Leak was caused by unbalanced calls to CVOpenGLESTextureCacheCreate and CFRelease