### PR TITLE
Applying fix for GPUImageUIElement

### DIFF
--- a/framework/Source/GPUImageUIElement.m
+++ b/framework/Source/GPUImageUIElement.m
@@ -100,6 +100,7 @@
     
     // TODO: This may not work
     outputFramebuffer = [[GPUImageContext sharedFramebufferCache] fetchFramebufferForSize:layerPixelSize textureOptions:self.outputTextureOptions onlyTexture:YES];
+    [outputFramebuffer disableReferenceCounting];
 
     glBindTexture(GL_TEXTURE_2D, [outputFramebuffer texture]);
     // no need to use self.outputTextureOptions here, we always need these texture options
@@ -115,6 +116,7 @@
             NSInteger textureIndexOfTarget = [[targetTextureIndices objectAtIndex:indexOfObject] integerValue];
             
             [currentTarget setInputSize:layerPixelSize atIndex:textureIndexOfTarget];
+            [currentTarget setInputFramebuffer:outputFramebuffer atIndex:textureIndexOfTarget]; 
             [currentTarget newFrameReadyAtTime:frameTime atIndex:textureIndexOfTarget];
         }
     }    


### PR DESCRIPTION
Allowing to update the UI Element from outside of frameProcessingCompletionBlock.
See: https://github.com/BradLarson/GPUImage/issues/2211#issuecomment-197210701

I must admit, that i do not completely unterstand why this works. But it solved my problem and apparently worked for some other people, too. Regarding the mentioned issue. I did not run into unwanted side-effects as of now.

Please review and point out if this is okay or if not, why.