### PR TITLE
Removed SYMROOT (fixing one Carthage bug)

### DIFF
--- a/framework/GPUImage.xcodeproj/project.pbxproj
+++ b/framework/GPUImage.xcodeproj/project.pbxproj
@@ -2498,7 +2498,6 @@
 				ONLY_ACTIVE_ARCH = YES;
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SDKROOT = iphoneos;
-				SYMROOT = "$(PROJECT_DIR)/../build";
 			};
 			name = Debug;
 		};
@@ -2531,7 +2530,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SDKROOT = iphoneos;
-				SYMROOT = "$(PROJECT_DIR)/../build";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;


### PR DESCRIPTION
According to https://github.com/Carthage/Carthage/issues/2220, using `SYMROOT` in the PBX file is legacy and causes Carthage failures, this commit just removes those lines, making Carthage succeed again (tested on my local fork, it works).
It should fix https://github.com/BradLarson/GPUImage/issues/2573