### PR TITLE
glfulsh before setCurrentContext

### DIFF
--- a/framework/Source/iOS/GPUImageContext.m
+++ b/framework/Source/iOS/GPUImageContext.m
@@ -80,6 +80,7 @@ static void *openGLESContextQueueKey;
     EAGLContext *imageProcessingContext = [self context];
     if ([EAGLContext currentContext] != imageProcessingContext)
     {
+        glFlush();
         [EAGLContext setCurrentContext:imageProcessingContext];
     }
 }
@@ -95,6 +96,7 @@ static void *openGLESContextQueueKey;
     EAGLContext *imageProcessingContext = [self context];
     if ([EAGLContext currentContext] != imageProcessingContext)
     {
+        glFlush();
         [EAGLContext setCurrentContext:imageProcessingContext];
     }
     
@@ -277,6 +279,7 @@ static void *openGLESContextQueueKey;
 {
     if (_context == nil)
     {
+        glFlush();
         _context = [self createContext];
         [EAGLContext setCurrentContext:_context];
         


### PR DESCRIPTION

At other thread run OpenGL commons and  not glfulsh before setCurrentContext,maybe get a EXC_BAD_ACCESS error. sorry for my poor English.