### PR TITLE
Fixes broken pod build and ignores the header file on macs

### DIFF
--- a/GPUImage.podspec
+++ b/GPUImage.podspec
@@ -18,6 +18,7 @@ Pod::Spec.new do |s|
   
   s.osx.deployment_target = '10.6'
   s.osx.exclude_files = 'framework/Source/iOS',
+		        'framework/Source/GPUImage.h',
                         'framework/Source/GPUImageFilterPipeline.*',
                         'framework/Source/GPUImageMovieComposition.*',
                         'framework/Source/GPUImageVideoCamera.*',


### PR DESCRIPTION
This fixes a build error for Mac users. The pod was trying to output both `GPUImage.h` and it caused a workspace error. Updating the podspec to ignore the iOS `GPUImage.h` file fixes the build.