### PR TITLE
add .plist key NSCameraUsageDescription

### DIFF
--- a/examples/iOS/FilterShowcase/FilterShowcase/FilterShowcase-Info.plist
+++ b/examples/iOS/FilterShowcase/FilterShowcase/FilterShowcase-Info.plist
@@ -43,5 +43,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>Can you allow GPUImage to use the camera?</string>
 </dict>
 </plist>


### PR DESCRIPTION
for avoid `[access] This app has crashed because it attempted to access privacy-sensitive data without a usage description.  The app's Info.plist must contain an NSCameraUsageDescription key with a string value explaining to the user how the app uses this data.` issue on start the app