### PR TITLE
feat: disable purging frame buffer when app in backgroud , just exit

### DIFF
--- a/framework/Source/GPUImageFramebufferCache.m
+++ b/framework/Source/GPUImageFramebufferCache.m
@@ -38,9 +38,14 @@
 #if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
     __unsafe_unretained __typeof__ (self) weakSelf = self;
     memoryWarningObserver = [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidReceiveMemoryWarningNotification object:nil queue:nil usingBlock:^(NSNotification *note) {
-        __typeof__ (self) strongSelf = weakSelf;
-        if (strongSelf) {
-            [strongSelf purgeAllUnassignedFramebuffers];
+        
+        if ([[UIApplication sharedApplication] applicationState] == UIApplicationStateActive) {
+            __typeof__ (self) strongSelf = weakSelf;
+            if (strongSelf) {
+                [strongSelf purgeAllUnassignedFramebuffers];
+            }
+        }else{
+            exit(0);
         }
     }];
 #else


### PR DESCRIPTION
If UIApplicationDidReceiveMemoryWarningNotification is posted while the app is in the background , 
calling [GPUImageFramebufferCache purgeAllUnassignedFramebuffers] may cause app crash . 
Just exit(0) is a better choice .

Here is  the crash info - 
Crashed: com.sunsetlakesoftware.GPUImage.openGLESContextQueue
0  libGPUSupportMercury.dylib     0x19b850f94 gpus_ReturnNotPermittedKillClient
1  AGXGLDriver                    0x1a030c1bc (null)
2  libGPUSupportMercury.dylib     0x19b851f44 gpusSubmitDataBuffers
3  AGXGLDriver                    0x1a030d77c (null) + 12704
4  IOAccelerator                  0x18e2a9d94 IOAccelContextTestResourceSysMem + 80
5  GLEngine                       0x1a0a867f0 gleTestObject + 308
6  GLEngine                       0x1a0a86684 glTestObjectAPPLE_Exec + 136
7  CoreVideo                      0x18e385368 CVPixelBufferOpenGLESTextureBacking::testTexture() + 92
8  CoreVideo                      0x18e381c48 CVOpenGLESTextureCache::bufferBackingNotInUse(CVBufferBacking*) + 160
9  CoreVideo                      0x18e378034 CVBufferBacking::releaseUsage() + 104
10 CoreVideo                      0x18e378430 CVOpenGLESTexture::finalize() + 56
11 CoreFoundation                 0x18bccc358 _CFRelease + 216
12 Trans                          0x100960c6c __41-[GPUImageFramebuffer destroyFramebuffer]_block_invoke (GPUImageFramebuffer.m:227)
13 Trans                          0x100971970 runSynchronouslyOnVideoProcessingQueue (GPUImageOutput.m:30)
14 Trans                          0x100960b94 -[GPUImageFramebuffer destroyFramebuffer] (GPUImageFramebuffer.m:238)
15 Trans                          0x100960724 -[GPUImageFramebuffer dealloc] (GPUImageFramebuffer.m:112)
16 CoreFoundation                 0x18bc44624 -[__NSDictionaryM removeAllObjects] + 520
17 Trans                          0x100961e48 __58-[GPUImageFramebufferCache purgeAllUnassignedFramebuffers]_block_invoke (GPUImageFramebufferCache.m:154)

