### PR TITLE
feature: add function `setupFilters` for GPUImageFilterGroup

### DIFF
--- a/framework/Source/GPUImageFilterGroup.h
+++ b/framework/Source/GPUImageFilterGroup.h
@@ -1,6 +1,8 @@
 #import "GPUImageOutput.h"
 #import "GPUImageFilter.h"
 
+typedef GPUImageOutput<GPUImageInput> FilterOutputType;
+
 @interface GPUImageFilterGroup : GPUImageOutput <GPUImageInput>
 {
     NSMutableArray *filters;
@@ -10,6 +12,8 @@
 @property(readwrite, nonatomic, strong) GPUImageOutput<GPUImageInput> *terminalFilter;
 @property(readwrite, nonatomic, strong) NSArray *initialFilters;
 @property(readwrite, nonatomic, strong) GPUImageOutput<GPUImageInput> *inputFilterToIgnoreForUpdates; 
+
++ (instancetype)filterGroupWithFilters:(NSArray <FilterOutputType *> *)filters;
 
 // Filter management
 - (void)addFilter:(GPUImageOutput<GPUImageInput> *)newFilter;

--- a/framework/Source/GPUImageFilterGroup.m
+++ b/framework/Source/GPUImageFilterGroup.m
@@ -19,6 +19,22 @@
     return self;
 }
 
++ (instancetype)filterGroupWithFilters:(NSArray <FilterOutputType *> *)filters {
+    if (filters.count == 0) {
+        return nil;
+    }
+
+    GPUImageFilterGroup *filterGroup = [[GPUImageFilterGroup alloc] init];
+    for (FilterOutputType *filter in filters) {
+        [filterGroup addFilter:filter];
+    }
+
+    [filterGroup setInitialFilters:filters];
+    [filterGroup setTerminalFilter:filters.lastObject];
+
+    return filterGroup;
+}
+
 #pragma mark -
 #pragma mark Filter management
 


### PR DESCRIPTION
feature: add function `setupFilters` for GPUImageFilterGroup

I am not sure the difference between `filters`, `initialFilters`, `terminalFilter` after tracing the code, but based on the example `FilterShowcase`, it looks like this class method could make it more convenient.