### PR TITLE
fix: run `CGSize currentViewSize = self.bounds.size;` on the main thr…

### DIFF
--- a/framework/Source/iOS/GPUImageView.m
+++ b/framework/Source/iOS/GPUImageView.m
@@ -233,45 +233,48 @@
 - (void)recalculateViewGeometry;
 {
     runSynchronouslyOnVideoProcessingQueue(^{
-        CGFloat heightScaling, widthScaling;
-        
-        CGSize currentViewSize = self.bounds.size;
-        
-        //    CGFloat imageAspectRatio = inputImageSize.width / inputImageSize.height;
-        //    CGFloat viewAspectRatio = currentViewSize.width / currentViewSize.height;
-        
-        CGRect insetRect = AVMakeRectWithAspectRatioInsideRect(inputImageSize, self.bounds);
-        
-        switch(_fillMode)
-        {
-            case kGPUImageFillModeStretch:
+        dispatch_async(dispatch_get_main_queue(), ^{
+            CGFloat heightScaling, widthScaling;
+
+            CGSize currentViewSize = self.bounds.size;
+
+            //    CGFloat imageAspectRatio = inputImageSize.width / inputImageSize.height;
+            //    CGFloat viewAspectRatio = currentViewSize.width / currentViewSize.height;
+
+            CGRect insetRect = AVMakeRectWithAspectRatioInsideRect(inputImageSize, self.bounds);
+
+            switch(_fillMode)
             {
-                widthScaling = 1.0;
-                heightScaling = 1.0;
-            }; break;
-            case kGPUImageFillModePreserveAspectRatio:
-            {
-                widthScaling = insetRect.size.width / currentViewSize.width;
-                heightScaling = insetRect.size.height / currentViewSize.height;
-            }; break;
-            case kGPUImageFillModePreserveAspectRatioAndFill:
-            {
-                //            CGFloat widthHolder = insetRect.size.width / currentViewSize.width;
-                widthScaling = currentViewSize.height / insetRect.size.height;
-                heightScaling = currentViewSize.width / insetRect.size.width;
-            }; break;
-        }
-        
-        imageVertices[0] = -widthScaling;
-        imageVertices[1] = -heightScaling;
-        imageVertices[2] = widthScaling;
-        imageVertices[3] = -heightScaling;
-        imageVertices[4] = -widthScaling;
-        imageVertices[5] = heightScaling;
-        imageVertices[6] = widthScaling;
-        imageVertices[7] = heightScaling;
+                case kGPUImageFillModeStretch:
+                {
+                    widthScaling = 1.0;
+                    heightScaling = 1.0;
+                }; break;
+                case kGPUImageFillModePreserveAspectRatio:
+                {
+                    widthScaling = insetRect.size.width / currentViewSize.width;
+                    heightScaling = insetRect.size.height / currentViewSize.height;
+                }; break;
+                case kGPUImageFillModePreserveAspectRatioAndFill:
+                {
+                    //            CGFloat widthHolder = insetRect.size.width / currentViewSize.width;
+                    widthScaling = currentViewSize.height / insetRect.size.height;
+                    heightScaling = currentViewSize.width / insetRect.size.width;
+                }; break;
+            }
+
+            runSynchronouslyOnVideoProcessingQueue(^{
+                imageVertices[0] = -widthScaling;
+                imageVertices[1] = -heightScaling;
+                imageVertices[2] = widthScaling;
+                imageVertices[3] = -heightScaling;
+                imageVertices[4] = -widthScaling;
+                imageVertices[5] = heightScaling;
+                imageVertices[6] = widthScaling;
+                imageVertices[7] = heightScaling;
+            });
+        });
     });
-    
 //    static const GLfloat imageVertices[] = {
 //        -1.0f, -1.0f,
 //        1.0f, -1.0f,


### PR DESCRIPTION
…ead to avoid crash on iOS 13, Xcode 11.